### PR TITLE
Update composable component name to match new namespace

### DIFF
--- a/trimble_driver_ros/CMakeLists.txt
+++ b/trimble_driver_ros/CMakeLists.txt
@@ -88,7 +88,7 @@ install(
 # These macros only work in the same scope as ament_package() due to a
 # variable not being set in the cache
 rclcpp_components_register_nodes(
-    gsof_client_ros "trimble_driver_ros::GsofClientRos")
+    gsof_client_ros "trmb_ros::GsofClientRos")
 
 include(CMakePackageConfigHelpers)
 write_basic_package_version_file(

--- a/trimble_driver_ros/launch/composable_gsof_client.py
+++ b/trimble_driver_ros/launch/composable_gsof_client.py
@@ -43,7 +43,7 @@ def generate_launch_description():
             composable_node_descriptions=[
                 ComposableNode(
                     package='trimble_driver_ros',
-                    plugin='trimble_driver_ros::GsofClientRos',
+                    plugin='trmb_ros::GsofClientRos',
                     name=LaunchConfiguration('node_name'),
                     parameters=[default_params, LaunchConfiguration('config')])
             ],


### PR DESCRIPTION
### Description

Update the component name in the `CMakeLists.txt` to match the namespace and name used in `RCLCPP_COMPONENTS_REGISTER_NODE` declaration.

### Reason

The composable node name was not found, since the class namespace and components namespace did not properly match.  This prevented the composable interface from working.

### Method / Design

A few minor changes were made:
  - Update namespace in `CmakeLists.txt` to match the class namespace
  - Update composable node example with the correct composable name

### Testing

Test Setup:
- `ros:humble-ros-base` Docker image
  - ROS2 Humble
  - Ubuntu 22.04

**Before**
Previously an error occured when trying to use the composable node:
```
$ ros2 launch trimble_driver_ros composable_gsof_client.py
[INFO] [launch]: Default logging verbosity is set to INFO
[INFO] [component_container-1]: process started with pid [13353]
[component_container-1] [ERROR] [1739302910.173571730] [trimble_container]: Failed to find class with the requested plugin name 'trimble_driver_ros::GsofClientRos' in the loaded library
[ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'gsof_client' of type 'trimble_driver_ros::GsofClientRos' in container '/trimble_container': Failed to find class with the requested plugin name.
```

**After**
After update (still an error due to no hardware being connected, but it launches properly):
```
$ ros2 run trimble_driver_ros gsof_client_node 
[ERROR] [1739303384.821282808] [gsof_client]: Error starting GSOF client: Connection refused. Either the port is accessible but no applications are listening on that port or the the server is already servicing the maximum number of clients.
terminate called after throwing an instance of 'trmb_ros::GsofClientRos::connection_error'
  what():  GsofClientRos could not start a connection to device. Connection refused. Either the port is accessible but no applications are listening on that port or the the server is already servicing the maximum number of clients.
[ros2run]: Aborted
```
