### PR TITLE
ci: Update ubuntu ARM github runner label

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -12,7 +12,7 @@ jobs:
             matrix:
                 os:
                     - ubuntu-latest
-                    - ubuntu-latest-arm
+                    - ubuntu-22.04-arm
         runs-on: ${{ matrix.os }}
         container:
             image: ros:rolling-ros-base


### PR DESCRIPTION
Following the labels shown [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) 