### PR TITLE
ci: disable whitesource SAST

### DIFF
--- a/.whitesource
+++ b/.whitesource
@@ -6,7 +6,7 @@
     "baseBranches": []
   },
   "scanSettingsSAST": {
-    "enableScan": true,
+    "enableScan": false,
     "scanPullRequests": true,
     "incrementalScan": true,
     "baseBranches": [],


### PR DESCRIPTION
Disable code scanning in whitesource since it is not yet available through Mend