### PR TITLE
fix(gsof_client): Remove unique_ptr wrapper on std::thread

### DIFF
--- a/trimble_driver/include/trimble_driver/gsof_client.h
+++ b/trimble_driver/include/trimble_driver/gsof_client.h
@@ -54,7 +54,7 @@ class GsofClient {
   void gsofChapterCallback(const std::vector<std::byte> &chapter);
 
  private:
-  std::unique_ptr<std::thread> tcp_thread_;
+  std::thread tcp_thread_;
   std::atomic_bool keep_running_;
 
   network::TcpClient tcp_client_;

--- a/trimble_driver/src/trimble_driver/gsof_client.cpp
+++ b/trimble_driver/src/trimble_driver/gsof_client.cpp
@@ -10,9 +10,9 @@
 
 namespace trmb {
 
-GsofClient::GsofClient(const std::string &ip_address, unsigned int port)
+GsofClient::GsofClient(const std::string& ip_address, unsigned int port)
     : keep_running_(true), tcp_client_(ip_address, port) {
-  gsof_stream_parser_.registerGsofChapterFoundCallback([this](const std::vector<std::byte> &chapter) {
+  gsof_stream_parser_.registerGsofChapterFoundCallback([this](const std::vector<std::byte>& chapter) {
     this->gsofChapterCallback<gsof::MessageParser<gsof::SupportedPublicMessages>>(chapter);
   });
 }
@@ -36,7 +36,7 @@ void GsofClient::stop() { keep_running_ = false; }
 
 std::vector<GsofClient::MessageCallback>::iterator GsofClient::registerCallback(
     gsof::Id id,
-    const GsofClient::MessageCallback &callback) {
+    const GsofClient::MessageCallback& callback) {
   if (message_callbacks_.count(id) == 0) {
     message_callbacks_[id] = std::vector<MessageCallback>();
   }
@@ -56,7 +56,7 @@ void GsofClient::grabAndParseTcp() {
   int bytes_rcvd = tcp_client_.receive();
   if (bytes_rcvd < 1) return;
 
-  auto &&buffer = tcp_client_.getBuffer();
+  auto&& buffer = tcp_client_.getBuffer();
   gsof_stream_parser_.readSome(buffer.data(), bytes_rcvd);
 }
 

--- a/trimble_driver/src/trimble_driver/gsof_client.cpp
+++ b/trimble_driver/src/trimble_driver/gsof_client.cpp
@@ -19,8 +19,8 @@ GsofClient::GsofClient(const std::string &ip_address, unsigned int port)
 
 GsofClient::~GsofClient() {
   stop();
-  if (tcp_thread_->joinable()) {
-    tcp_thread_->join();
+  if (tcp_thread_.joinable()) {
+    tcp_thread_.join();
   }
 }
 
@@ -28,7 +28,7 @@ util::Status GsofClient::start() {
   util::Status status = tcp_client_.open();
   if (!status) return status;
 
-  tcp_thread_ = std::make_unique<std::thread>(&GsofClient::runTcpConnection, this);
+  tcp_thread_ = std::thread(&GsofClient::runTcpConnection, this);
   return status;
 }
 

--- a/trimble_driver/test/CMakeLists.txt
+++ b/trimble_driver/test/CMakeLists.txt
@@ -7,6 +7,7 @@ trmb_cc_test(
         trimble_driver_test
     SRCS
         test_byteswap.cpp
+        test_client.cpp
         test_gsof.cpp
         test_gsof_streaming.cpp
         test_ros_conversions.cpp

--- a/trimble_driver/test/test_client.cpp
+++ b/trimble_driver/test/test_client.cpp
@@ -3,64 +3,55 @@
  * All rights reserved.
  */
 
-#include <boost/asio.hpp>
-
 #include <gtest/gtest.h>
+
+#include <boost/asio.hpp>
 
 #include "trimble_driver/gsof_client.h"
 
-class ClientTest : public ::testing::Test
-{
-protected:
-	ClientTest()
-	  : acceptor_(io_context_)
-	{
-	}
+class ClientTest : public ::testing::Test {
+ protected:
+  ClientTest() : acceptor_(io_context_) {}
 
-	void SetUp() override
-	{
-		boost::system::error_code ec;
-		acceptor_.open(boost::asio::ip::tcp::v4(), ec);
-		ASSERT_FALSE(ec) << ec.message();
+  void SetUp() override {
+    boost::system::error_code ec;
+    acceptor_.open(boost::asio::ip::tcp::v4(), ec);
+    ASSERT_FALSE(ec) << ec.message();
 
-		acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true), ec);
-		ASSERT_FALSE(ec) << ec.message();
+    acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true), ec);
+    ASSERT_FALSE(ec) << ec.message();
 
-		const boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address_v4::loopback(), 0);
-		acceptor_.bind(endpoint, ec);
-		ASSERT_FALSE(ec) << ec.message();
+    const boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address_v4::loopback(), 0);
+    acceptor_.bind(endpoint, ec);
+    ASSERT_FALSE(ec) << ec.message();
 
-		acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
-		ASSERT_FALSE(ec) << ec.message();
+    acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
+    ASSERT_FALSE(ec) << ec.message();
 
-		port_ = acceptor_.local_endpoint(ec).port();
-		ASSERT_FALSE(ec) << ec.message();
-	}
+    port_ = acceptor_.local_endpoint(ec).port();
+    ASSERT_FALSE(ec) << ec.message();
+  }
 
-	void TearDown() override
-	{
-		boost::system::error_code ec;
-		acceptor_.close(ec);
-	}
+  void TearDown() override {
+    boost::system::error_code ec;
+    acceptor_.close(ec);
+  }
 
-	boost::asio::io_context io_context_;
-	boost::asio::ip::tcp::acceptor acceptor_;
-	std::uint16_t port_ = 0;
+  boost::asio::io_context io_context_;
+  boost::asio::ip::tcp::acceptor acceptor_;
+  std::uint16_t port_ = 0;
 };
 
-TEST_F(ClientTest, client)
-{
-	EXPECT_GT(port_, 0);
-    trmb::GsofClient client("127.0.0.1", port_);
-    
-    EXPECT_NO_THROW(client.start());
-    EXPECT_NO_THROW(client.stop());
+TEST_F(ClientTest, client) {
+  EXPECT_GT(port_, 0);
+  trmb::GsofClient client("127.0.0.1", port_);
+
+  EXPECT_NO_THROW(client.start());
+  EXPECT_NO_THROW(client.stop());
 }
 
-TEST_F(ClientTest, clientDestructorWithoutStarting)
-{
-    // See bug https://github.com/trimble-oss/trimble_driver_ros/issues/32
-	EXPECT_GT(port_, 0);
-    trmb::GsofClient client("127.0.0.1", port_);
+TEST_F(ClientTest, clientDestructorWithoutStarting) {
+  // See bug https://github.com/trimble-oss/trimble_driver_ros/issues/32
+  EXPECT_GT(port_, 0);
+  trmb::GsofClient client("127.0.0.1", port_);
 }
-

--- a/trimble_driver/test/test_client.cpp
+++ b/trimble_driver/test/test_client.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2026. Trimble Inc.
+ * All rights reserved.
+ */
+
+#include <boost/asio.hpp>
+
+#include <gtest/gtest.h>
+
+#include "trimble_driver/gsof_client.h"
+
+class ClientTest : public ::testing::Test
+{
+protected:
+	ClientTest()
+	  : acceptor_(io_context_)
+	{
+	}
+
+	void SetUp() override
+	{
+		boost::system::error_code ec;
+		acceptor_.open(boost::asio::ip::tcp::v4(), ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		acceptor_.set_option(boost::asio::ip::tcp::acceptor::reuse_address(true), ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		const boost::asio::ip::tcp::endpoint endpoint(boost::asio::ip::address_v4::loopback(), 0);
+		acceptor_.bind(endpoint, ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		acceptor_.listen(boost::asio::socket_base::max_listen_connections, ec);
+		ASSERT_FALSE(ec) << ec.message();
+
+		port_ = acceptor_.local_endpoint(ec).port();
+		ASSERT_FALSE(ec) << ec.message();
+	}
+
+	void TearDown() override
+	{
+		boost::system::error_code ec;
+		acceptor_.close(ec);
+	}
+
+	boost::asio::io_context io_context_;
+	boost::asio::ip::tcp::acceptor acceptor_;
+	std::uint16_t port_ = 0;
+};
+
+TEST_F(ClientTest, client)
+{
+	EXPECT_GT(port_, 0);
+    trmb::GsofClient client("127.0.0.1", port_);
+    
+    EXPECT_NO_THROW(client.start());
+    EXPECT_NO_THROW(client.stop());
+}
+
+TEST_F(ClientTest, clientDestructorWithoutStarting)
+{
+    // See bug https://github.com/trimble-oss/trimble_driver_ros/issues/32
+	EXPECT_GT(port_, 0);
+    trmb::GsofClient client("127.0.0.1", port_);
+}
+


### PR DESCRIPTION
Easy fix to prevent segfault when the thread is not created