### PR TITLE
docs: render security reporting link normally

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@
 
 Report security vulnerabilities to the Trimble Cybersecurity team at:
 
-    https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form
+<https://www.trimble.com/en/our-commitment/responsible-business/data-privacy-and-security/report-cybersecurity-issues/form>
 
 Report security vulnerabilities in third-party modules to the person or team maintaining the module.
 


### PR DESCRIPTION
Follow-up to #34.

This keeps the public Trimble security reporting URL the same, but renders it as a normal Markdown autolink instead of an indented code block. That preserves the policy-compliant content while improving link rendering and accessibility.
