### PR TITLE
refactor: make unit tests use synthetic data instead of pcaps

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -41,4 +41,5 @@ jobs:
               run: |
                 source /usr/share/colcon_cd/function/colcon_cd.sh
                 colcon_cd trimble_driver
+                cd test/data
                 ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -39,5 +39,5 @@ jobs:
                 import-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Run extra pcap tests
               run: |
-                cd ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/src/trimble_driver/test/data
+                cd ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/src/trimble_driver_ros/trimble_driver/test/data
                 ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -39,5 +39,7 @@ jobs:
                 import-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Run extra pcap tests
               run: |
+                echo "=== Current Directory ($GITHUB_WORKSPACE) ==="
+                find . -maxdepth 4 -not -path '*/.*'
                 cd ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/src/trimble_driver_ros/trimble_driver/test/data
                 ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -27,7 +27,7 @@ jobs:
                 git lfs install
             - name: Extra colcon extensions
               run: |
-                apt install -y python3-colcon-lcov-result python3-colcon-coveragepy-result
+                apt install -y python3-colcon-lcov-result python3-colcon-coveragepy-result python3-colcon-cd
             - uses: ros-tooling/action-ros-ci@9125cf1fa1f87e7830ed1c77f8b1885ee649b9a0 # 0.4.6
               id: action_ros_ci_step
               with:
@@ -39,7 +39,6 @@ jobs:
                 import-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Run extra pcap tests
               run: |
-                echo "=== Current Directory ($GITHUB_WORKSPACE) ==="
-                find . -maxdepth 4 -not -path '*/.*'
-                cd ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/src/trimble_driver_ros/trimble_driver/test/data
+                source /usr/share/colcon_cd/function/colcon_cd.sh
+                colcon_cd trimble_driver
                 ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -36,3 +36,7 @@ jobs:
                     trimble_interfaces
                 target-ros2-distro: jazzy
                 import-token: ${{ secrets.GITHUB_TOKEN }}
+            - name: Run extra pcap tests
+              run: |
+                cd trimble_driver/test/data
+                $GITHUB_WORKSPACE/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -42,4 +42,4 @@ jobs:
                 source /usr/share/colcon_cd/function/colcon_cd.sh
                 colcon_cd trimble_driver
                 cd test/data
-                ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 
+                $GITHUB_WORKSPACE/${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -40,6 +40,7 @@ jobs:
             - name: Run extra pcap tests
               run: |
                 source /usr/share/colcon_cd/function/colcon_cd.sh
+                source $GITHUB_WORKSPACE/${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/install/setup.bash
                 colcon_cd trimble_driver
                 cd test/data
                 $GITHUB_WORKSPACE/${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -29,6 +29,7 @@ jobs:
               run: |
                 apt install -y python3-colcon-lcov-result python3-colcon-coveragepy-result
             - uses: ros-tooling/action-ros-ci@9125cf1fa1f87e7830ed1c77f8b1885ee649b9a0 # 0.4.6
+              id: action_ros_ci_step
               with:
                 package-name: >
                     trimble_driver
@@ -38,5 +39,5 @@ jobs:
                 import-token: ${{ secrets.GITHUB_TOKEN }}
             - name: Run extra pcap tests
               run: |
-                cd trimble_driver/test/data
-                $GITHUB_WORKSPACE/build/trimble_driver/bin/trimble_driver_pcap_test 
+                cd ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/src/trimble_driver/test/data
+                ${{ steps.action_ros_ci_step.outputs.ros-workspace-directory-name }}/build/trimble_driver/bin/trimble_driver_pcap_test 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Building can be done through the typical ROS workflow of using `rosdep` and `col
    cd ~/colcon_ws/src
    git clone ...
    ```
-   [Optional] ownload the test files to run the unit tests.
+   [Optional] Download the test files to run pcap based unit tests with real data
    ```
    git lfs pull
    ```
@@ -81,6 +81,11 @@ Building can be done through the typical ROS workflow of using `rosdep` and `col
 4. [Optional] Run unit tests
    ```
    colcon test --event-handlers console_direct+
+   ```
+5. [Optional] Run pcap based unit tests
+   ```
+   cd trimble_driver/test/data
+   ${workspace_root}/build/trimble_driver/bin/trimble_driver_pcap_test
    ```
 
 ## Running

--- a/trimble_driver/cmake/macros.cmake
+++ b/trimble_driver/cmake/macros.cmake
@@ -145,9 +145,11 @@ endfunction(trmb_cc_exec)
 # INC_SYS: System includes
 # LINKOPTS: List of link options
 # ADD_GTEST_MAIN: Link to the default googletest main() implementation
+# NO_DISCOVER: Build the test executable but do not register its cases with ctest, so they are
+#              excluded from the default test and coverage runs and must be invoked manually.
 function(trmb_cc_test)
   cmake_parse_arguments(TRMB_CC_TEST
-    "ADD_GTEST_MAIN"
+    "ADD_GTEST_MAIN;NO_DISCOVER"
     "NAME;WORKING_DIR"
     "SRCS;DEPS;COPTS;INC;INC_SYS;LINKOPTS"
     ${ARGN})
@@ -181,16 +183,20 @@ function(trmb_cc_test)
       ARCHIVE_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib"
       PDB_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin")
 
-  gtest_discover_tests(${_NAME}
-    WORKING_DIRECTORY ${TRMB_CC_TEST_WORKING_DIR}
-    XML_OUTPUT_DIR "${CMAKE_BINARY_DIR}/test_results/")
+  if(NOT TRMB_CC_TEST_NO_DISCOVER)
+    gtest_discover_tests(${_NAME}
+      WORKING_DIRECTORY ${TRMB_CC_TEST_WORKING_DIR}
+      XML_OUTPUT_DIR "${CMAKE_BINARY_DIR}/test_results/")
+  endif()
 
   # Add TOPSRCDIR
   foreach(script_src IN ITEMS ${TRMB_CC_TEST_SRCS})
     set_property(SOURCE ${script_src} APPEND PROPERTY COMPILE_DEFINITIONS "TOP_SRC_DIR=\"${PROJECT_SOURCE_DIR}\"")
   endforeach()
 
-  list(APPEND TRMB_UNIT_TESTS ${_NAME})
+  if(NOT TRMB_CC_TEST_NO_DISCOVER)
+    list(APPEND TRMB_UNIT_TESTS ${_NAME})
+  endif()
 
 endfunction(trmb_cc_test)
 

--- a/trimble_driver/test/CMakeLists.txt
+++ b/trimble_driver/test/CMakeLists.txt
@@ -25,3 +25,29 @@ trmb_cc_test(
 if(tf2_geometry_msgs_VERSION_MINOR LESS 25)
   target_compile_definitions(trimble_driver_test PRIVATE TRMB_TF2_HEADER_DEPRECATED)
 endif()
+
+# Regression tests against captures from real receivers. NO_DISCOVER keeps them out of ctest, and therefore out of
+# `colcon test` and the coverage run, because they depend on the Git LFS payloads in test/data. Run them with
+# `cd trimble_driver/test/data && <build>/bin/trimble_driver_pcap_test`.
+trmb_cc_test(
+    NAME
+        trimble_driver_pcap_test
+    SRCS
+        test_gsof_pcap.cpp
+        test_gsof_streaming_pcap.cpp
+        test_ros_conversions_pcap.cpp
+    DEPS
+        ${PROJECT_NAME}::trimble_driver
+        ${PROJECT_NAME}::ros_conversions
+        tf2_geometry_msgs::tf2_geometry_msgs
+    COPTS
+        ${COMMON_COMPILE_FLAGS}
+    WORKING_DIR
+        ${CMAKE_CURRENT_SOURCE_DIR}/data
+    ADD_GTEST_MAIN
+    NO_DISCOVER
+)
+
+if(tf2_geometry_msgs_VERSION_MINOR LESS 25)
+  target_compile_definitions(trimble_driver_pcap_test PRIVATE TRMB_TF2_HEADER_DEPRECATED)
+endif()

--- a/trimble_driver/test/gsof_record_builder.h
+++ b/trimble_driver/test/gsof_record_builder.h
@@ -33,8 +33,11 @@ std::vector<std::byte> serialize(MessageType message) {
 /**
  * @brief Wraps an already big-endian payload into a single GENOUT page.
  */
-inline std::vector<std::byte> makeGenoutPage(const std::byte *payload, std::size_t payload_length, uint8_t tx_num,
-                                             uint8_t page_idx, uint8_t max_page_idx) {
+inline std::vector<std::byte> makeGenoutPage(const std::byte *payload,
+                                             std::size_t payload_length,
+                                             uint8_t tx_num,
+                                             uint8_t page_idx,
+                                             uint8_t max_page_idx) {
   using trmb::gsof::record::Footer;
   using trmb::gsof::record::Header;
 

--- a/trimble_driver/test/gsof_record_builder.h
+++ b/trimble_driver/test/gsof_record_builder.h
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024. Trimble Inc.
+ * All rights reserved.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <vector>
+
+#include "trimble_driver/gsof/gsof.h"
+
+/**
+ * Helpers for building GSOF byte streams in tests so that they do not depend on captured pcap files.
+ */
+namespace gsof_test {
+
+/**
+ * @brief Byteswaps a GSOF message into its on-the-wire (big endian) representation.
+ *
+ * Only usable for messages whose struct layout matches the wire layout, i.e. no optional or variable length fields.
+ */
+template <class MessageType>
+std::vector<std::byte> serialize(MessageType message) {
+  message.switchEndianess();
+  std::vector<std::byte> bytes(sizeof(MessageType));
+  std::memcpy(bytes.data(), &message, bytes.size());
+  return bytes;
+}
+
+/**
+ * @brief Wraps an already big-endian payload into a single GENOUT page.
+ */
+inline std::vector<std::byte> makeGenoutPage(const std::byte *payload, std::size_t payload_length, uint8_t tx_num,
+                                             uint8_t page_idx, uint8_t max_page_idx) {
+  using trmb::gsof::record::Footer;
+  using trmb::gsof::record::Header;
+
+  Header header{};
+  header.start_tx     = trmb::gsof::START_TX;
+  header.status       = 0;
+  header.type         = trmb::gsof::GENOUT;
+  header.data_len     = static_cast<uint8_t>(payload_length + trmb::gsof::NUM_HEADER_BYTES_IN_DATA_LENGTH);
+  header.tx_num       = tx_num;
+  header.page_idx     = page_idx;
+  header.max_page_idx = max_page_idx;
+
+  std::vector<std::byte> page(sizeof(Header) + payload_length + sizeof(Footer));
+  std::memcpy(page.data(), &header, sizeof(Header));
+  std::memcpy(page.data() + sizeof(Header), payload, payload_length);
+
+  constexpr std::size_t k_checksum_data_start = 4;  // (1) stx + (1) status + (1) type + (1) data_len
+  unsigned int checksum                       = header.status + header.type + header.data_len;
+  for (std::size_t i = k_checksum_data_start; i < header.data_len + k_checksum_data_start; ++i) {
+    checksum += static_cast<unsigned int>(page[i]);
+  }
+
+  const Footer footer{static_cast<uint8_t>(checksum % 256), trmb::gsof::END_TX};
+  std::memcpy(page.data() + sizeof(Header) + payload_length, &footer, sizeof(Footer));
+
+  return page;
+}
+
+/**
+ * @brief Wraps one or more already big-endian GSOF messages into a single page GENOUT record.
+ */
+inline std::vector<std::byte> makeGenoutRecord(const std::byte *messages, std::size_t messages_length) {
+  return makeGenoutPage(messages, messages_length, 0, 0, 0);
+}
+
+/**
+ * @brief Concatenates messages into as few GENOUT pages as the single byte data length field allows.
+ *
+ * Messages are never split across a page boundary, which is how receivers actually page a transmission.
+ */
+inline std::vector<std::byte> makeGenoutTransmission(const std::vector<std::vector<std::byte>> &messages,
+                                                     uint8_t tx_num) {
+  constexpr std::size_t k_max_page_payload = 255 - trmb::gsof::NUM_HEADER_BYTES_IN_DATA_LENGTH;
+
+  std::vector<std::vector<std::byte>> page_payloads(1);
+  for (const auto &message : messages) {
+    if (!page_payloads.back().empty() && page_payloads.back().size() + message.size() > k_max_page_payload) {
+      page_payloads.emplace_back();
+    }
+    page_payloads.back().insert(page_payloads.back().end(), message.begin(), message.end());
+  }
+
+  const auto max_page_idx = static_cast<uint8_t>(page_payloads.size() - 1);
+
+  std::vector<std::byte> transmission;
+  for (std::size_t i = 0; i < page_payloads.size(); ++i) {
+    const auto page =
+        makeGenoutPage(page_payloads[i].data(), page_payloads[i].size(), tx_num, static_cast<uint8_t>(i), max_page_idx);
+    transmission.insert(transmission.end(), page.begin(), page.end());
+  }
+
+  return transmission;
+}
+
+}  // namespace gsof_test

--- a/trimble_driver/test/test_gsof.cpp
+++ b/trimble_driver/test/test_gsof.cpp
@@ -5,43 +5,44 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <optional>
+#include <random>
+#include <vector>
 
-#include "streaming_test.h"
+#include "gsof_record_builder.h"
 #include "trimble_driver/gsof/packet_parser.h"
 #include "trimble_driver/gsof/stream_page_parser.h"
 
+using gsof_test::makeGenoutRecord;
+using gsof_test::serialize;
 using trmb::gsof::Message;
 using trmb::gsof::PacketParser;
 using trmb::gsof::PublicPacketParser;
 
-static constexpr char k_apx18_ip_addr[]    = "238.0.0.1";
-static constexpr int k_apx18_port          = 5018;
-static constexpr char k_applus60_ip_addr[] = "238.0.0.1";
-static constexpr int k_applus60_port       = 5018;
+TEST(GsofParsingTest, positionTimeInfoGsof1) {
+  using namespace trmb::gsof;
 
-class Applus60Gsof : public ::testing::Test {
- public:
-  std::optional<PublicPacketParser> openPcap(const std::string &filename) {
-    pcap_reader_.emplace(filename, k_applus60_ip_addr, k_applus60_port, network::ProtocolType::TCP);
-    if (!(*pcap_reader_)) return std::nullopt;
+  const auto record = [] {
+    PositionTimeInfo expected{};
+    expected.header.type                = GSOF_ID_1_POS_TIME;
+    expected.header.length              = sizeof(PositionTimeInfo) - sizeof(Header);
+    expected.gps_time_ms                = 162117007;
+    expected.gps_week                   = 2225;
+    expected.number_space_vehicles_used = 25;
+    expected.position_flags_1           = 0b1010'1111;
+    expected.position_flags_2           = 0;
+    expected.init_num                   = 0;
 
-    pcap_reader_->readSingle(&payload_);
-    if (payload_.data == nullptr) return std::nullopt;
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
 
-    return PacketParser(reinterpret_cast<const std::byte *>(payload_.data), payload_.length);
-  }
-
- protected:
-  std::optional<network::PcapReader> pcap_reader_ = std::nullopt;
-  network::NonOwningBuffer payload_{nullptr, 0};
-};
-
-TEST_F(Applus60Gsof, positionTimeInfoGsof1) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof1.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -49,8 +50,8 @@ TEST_F(Applus60Gsof, positionTimeInfoGsof1) {
   ASSERT_EQ(it->getHeader().type, 0x01);
   ASSERT_EQ(it->getHeader().length, 10);
 
-  using namespace trmb::gsof;
   auto position_time = it->as<PositionTimeInfo>();
+  ASSERT_EQ(position_time.gps_time_ms, 162117007u);
   ASSERT_EQ(position_time.gps_week, 2225);
   ASSERT_EQ(position_time.number_space_vehicles_used, 25);
   ASSERT_TRUE(position_time.isNewPos());
@@ -70,11 +71,24 @@ TEST_F(Applus60Gsof, positionTimeInfoGsof1) {
   ASSERT_FALSE(position_time.isBeaconDGPS());
 }
 
-TEST_F(Applus60Gsof, latLongHeightGsof2) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof2.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, latLongHeightGsof2) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    LatLongHeight expected{};
+    expected.header.type   = GSOF_ID_2_LLH;
+    expected.header.length = sizeof(LatLongHeight) - sizeof(Header);
+    expected.lla.latitude  = 0.7654321;
+    expected.lla.longitude = -1.3876543;
+    expected.lla.altitude  = 168.25;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -84,20 +98,31 @@ TEST_F(Applus60Gsof, latLongHeightGsof2) {
   ASSERT_EQ(header.type, 0x02);
   ASSERT_EQ(header.length, 24);
 
-  using namespace trmb::gsof;
   const auto lla = it->as<LatLongHeight>();
 
-  // Using approximate office coordinates
-  ASSERT_NEAR(lla.lla.latitude, 0.77, 1e-2);
-  ASSERT_NEAR(lla.lla.longitude, -1.39, 1e-2);
-  ASSERT_NEAR(lla.lla.altitude, 168, 1);
+  ASSERT_DOUBLE_EQ(lla.lla.latitude, 0.7654321);
+  ASSERT_DOUBLE_EQ(lla.lla.longitude, -1.3876543);
+  ASSERT_DOUBLE_EQ(lla.lla.altitude, 168.25);
 }
 
-TEST_F(Applus60Gsof, ecefPositionGsof3) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof3.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, ecefPositionGsof3) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    EcefPosition expected{};
+    expected.header.type   = GSOF_ID_3_ECEF;
+    expected.header.length = sizeof(EcefPosition) - sizeof(Header);
+    expected.pos.x         = 848942.99;
+    expected.pos.y         = -4527384.15;
+    expected.pos.z         = 4397104.00;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -107,20 +132,31 @@ TEST_F(Applus60Gsof, ecefPositionGsof3) {
   ASSERT_EQ(header.type, 0x03);
   ASSERT_EQ(header.length, 24);
 
-  using namespace trmb::gsof;
   const auto ecef = it->as<EcefPosition>();
 
-  // Looked at GUI and converted approximate coordinates of degrees-minutes-seconds to ecef
-  ASSERT_NEAR(ecef.pos.x, 848942.99, 10);
-  ASSERT_NEAR(ecef.pos.y, -4527384.15, 10);
-  ASSERT_NEAR(ecef.pos.z, 4397104.00, 10);
+  ASSERT_DOUBLE_EQ(ecef.pos.x, 848942.99);
+  ASSERT_DOUBLE_EQ(ecef.pos.y, -4527384.15);
+  ASSERT_DOUBLE_EQ(ecef.pos.z, 4397104.00);
 }
 
-TEST_F(Applus60Gsof, ecefDeltaGsof6) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof6.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, ecefDeltaGsof6) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    EcefDelta expected{};
+    expected.header.type   = GSOF_ID_6_ECEF_DELTA;
+    expected.header.length = sizeof(EcefDelta) - sizeof(Header);
+    expected.delta.x       = -3473.5847978937672;
+    expected.delta.y       = 10602.019044206478;
+    expected.delta.z       = 11631.403884239495;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -130,21 +166,31 @@ TEST_F(Applus60Gsof, ecefDeltaGsof6) {
   ASSERT_EQ(header.type, 0x06);
   ASSERT_EQ(header.length, 24);
 
-  using namespace trmb::gsof;
   const auto ecef_delta = it->as<EcefDelta>();
 
-  // Converted from bytes shown in wireshark
-  // RTCMv3 input was from apply-bb-01.ddns.net:2101/Downtown_Base_RTCM_32_MSM4
-  ASSERT_NEAR(ecef_delta.delta.x, -3473.5847978937672, 1e-4);
-  ASSERT_NEAR(ecef_delta.delta.y, 10602.019044206478, 1e-4);
-  ASSERT_NEAR(ecef_delta.delta.z, 11631.403884239495, 1e-4);
+  ASSERT_DOUBLE_EQ(ecef_delta.delta.x, -3473.5847978937672);
+  ASSERT_DOUBLE_EQ(ecef_delta.delta.y, 10602.019044206478);
+  ASSERT_DOUBLE_EQ(ecef_delta.delta.z, 11631.403884239495);
 }
 
-TEST_F(Applus60Gsof, tplaneDeltaGsof7) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof7.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, tplaneDeltaGsof7) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    TangentPlaneDelta expected{};
+    expected.header.type   = GSOF_ID_7_TPLANE_ENU;
+    expected.header.length = sizeof(TangentPlaneDelta) - sizeof(Header);
+    expected.enu.east      = -1456.685759244824;
+    expected.enu.north     = 16051.050661617326;
+    expected.enu.up        = 43.853000930700546;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -154,21 +200,42 @@ TEST_F(Applus60Gsof, tplaneDeltaGsof7) {
   ASSERT_EQ(header.type, 0x07);
   ASSERT_EQ(header.length, 24);
 
-  using namespace trmb::gsof;
   const auto tplane_delta = it->as<TangentPlaneDelta>();
 
-  // Converted from bytes shown in wireshark
-  // RTCMv3 input was from appl-bb-01.ddns.net:2101/Downtown_Base_RTCM_32_MSM4
-  ASSERT_NEAR(tplane_delta.enu.east, -1456.685759244824, 1e-4);
-  ASSERT_NEAR(tplane_delta.enu.north, 16051.050661617326, 1e-4);
-  ASSERT_NEAR(tplane_delta.enu.up, 43.853000930700546, 1e-4);
+  ASSERT_DOUBLE_EQ(tplane_delta.enu.east, -1456.685759244824);
+  ASSERT_DOUBLE_EQ(tplane_delta.enu.north, 16051.050661617326);
+  ASSERT_DOUBLE_EQ(tplane_delta.enu.up, 43.853000930700546);
 }
 
-TEST_F(Applus60Gsof, velocityGsof8) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof8.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, velocityGsof8) {
+  using namespace trmb::gsof;
+
+  constexpr uint8_t k_length_without_local_heading = 13;
+
+  const auto record = [] {
+    // Velocity has an optional trailing field so it cannot be memcpy'd as a whole struct.
+    std::vector<std::byte> message;
+    const auto append = [&message](auto value) {
+      if constexpr (sizeof(value) > 1) {
+        byteswapInPlace(&value);
+      }
+      const auto *bytes = reinterpret_cast<const std::byte *>(&value);
+      message.insert(message.end(), bytes, bytes + sizeof(value));
+    };
+
+    append(static_cast<uint8_t>(GSOF_ID_8_VELOCITY));
+    append(k_length_without_local_heading);
+    append(static_cast<uint8_t>(0b0000'0101));
+    append(0.00597169f);
+    append(2.062232f);
+    append(-0.0006348496f);
+
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -176,12 +243,10 @@ TEST_F(Applus60Gsof, velocityGsof8) {
 
   const auto &header = it->getHeader();
   ASSERT_EQ(header.type, 0x08);
-  ASSERT_EQ(header.length, 13);
+  ASSERT_EQ(header.length, k_length_without_local_heading);
 
-  using namespace trmb::gsof;
   const auto velocity = it->as<Velocity>();
 
-  // Converted from bytes shown in wireshark
   ASSERT_FLOAT_EQ(velocity.velocity, 0.00597169);
   ASSERT_FLOAT_EQ(velocity.heading, 2.062232);
   ASSERT_FLOAT_EQ(velocity.vertical_velocity, -0.0006348496);
@@ -192,11 +257,25 @@ TEST_F(Applus60Gsof, velocityGsof8) {
   ASSERT_TRUE(velocity.isHeadingDataValid());
 }
 
-TEST_F(Applus60Gsof, pdopInfoGsof9) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof9.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, pdopInfoGsof9) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    PdopInfo expected{};
+    expected.header.type     = GSOF_ID_9_DOP;
+    expected.header.length   = sizeof(PdopInfo) - sizeof(Header);
+    expected.position_dop    = 0.9000375f;
+    expected.horiziontal_dop = 0.488651454f;
+    expected.vertical_dop    = 0.7558355f;
+    expected.time_dop        = 1.13949406f;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -206,21 +285,32 @@ TEST_F(Applus60Gsof, pdopInfoGsof9) {
   ASSERT_EQ(header.type, 0x09);
   ASSERT_EQ(header.length, 16);
 
-  using namespace trmb::gsof;
   const auto dop = it->as<PdopInfo>();
 
-  // Converted from bytes shown in wireshark
   ASSERT_FLOAT_EQ(dop.position_dop, 0.9000375);
   ASSERT_FLOAT_EQ(dop.horiziontal_dop, 0.488651454);
   ASSERT_FLOAT_EQ(dop.vertical_dop, 0.7558355);
   ASSERT_FLOAT_EQ(dop.time_dop, 1.13949406);
 }
 
-TEST_F(Applus60Gsof, clockInfoGsof10) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof10.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, clockInfoGsof10) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    ClockInfo expected{};
+    expected.header.type   = GSOF_ID_10_CLOCK_INFO;
+    expected.header.length = sizeof(ClockInfo) - sizeof(Header);
+    expected.clock_flags   = 0b0000'0111;
+    expected.clock_offset  = 0.007924753666675877;
+    expected.freq_offset   = -1.6607935199691757;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -230,22 +320,40 @@ TEST_F(Applus60Gsof, clockInfoGsof10) {
   ASSERT_EQ(header.type, 10);
   ASSERT_EQ(header.length, 17);
 
-  using namespace trmb::gsof;
   const auto clock = it->as<ClockInfo>();
 
   ASSERT_TRUE(clock.isClockOffsetValid());
   ASSERT_TRUE(clock.isFreqOffsetValid());
   ASSERT_TRUE(clock.isReceiverInAnywhereFixMode());
 
-  ASSERT_NEAR(clock.clock_offset, 0.007924753666675877, 1e-5);
-  ASSERT_NEAR(clock.freq_offset, -1.6607935199691757, 1e-5);
+  ASSERT_DOUBLE_EQ(clock.clock_offset, 0.007924753666675877);
+  ASSERT_DOUBLE_EQ(clock.freq_offset, -1.6607935199691757);
 }
 
-TEST_F(Applus60Gsof, positionVcvGsof11) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof11.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, positionVcvGsof11) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    PositionVcvInfo expected{};
+    expected.header.type   = GSOF_ID_11_POS_VCV_INFO;
+    expected.header.length = sizeof(PositionVcvInfo) - sizeof(Header);
+    expected.position_rms  = 0.001f;
+    expected.xx            = 0.0004194359f;
+    expected.xy            = 0.0000253239959f;
+    expected.xz            = 0.0000135725622f;
+    expected.yy            = 0.000340281957f;
+    expected.yz            = 0.0000268921121f;
+    expected.zz            = 0.0003106595f;
+    expected.unit_var      = 1.0f;
+    expected.num_epochs    = 0;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -255,7 +363,6 @@ TEST_F(Applus60Gsof, positionVcvGsof11) {
   ASSERT_EQ(header.type, 11);
   ASSERT_EQ(header.length, 34);
 
-  using namespace trmb::gsof;
   const auto covariance = it->as<PositionVcvInfo>();
 
   ASSERT_FLOAT_EQ(covariance.position_rms, 0.001);
@@ -269,11 +376,31 @@ TEST_F(Applus60Gsof, positionVcvGsof11) {
   ASSERT_EQ(covariance.num_epochs, 0);
 }
 
-TEST_F(Applus60Gsof, positionSigmaGsof12) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof12.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, positionSigmaGsof12) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    PositionSigmaInfo expected{};
+    expected.header.type           = GSOF_ID_12_POS_SIGMA;
+    expected.header.length         = sizeof(PositionSigmaInfo) - sizeof(Header);
+    expected.position_rms          = 0.001f;
+    expected.sigma_east            = 0.200461134f;
+    expected.sigma_north           = 0.0194671229f;
+    expected.covariance_east_north = -0.000291388424f;
+    expected.sigma_up              = 0.0169321168f;
+    expected.semi_major_axis       = 0.200466454f;
+    expected.semi_minor_axis       = 0.0194122624f;
+    expected.orientation           = 90.41939f;
+    expected.unit_variance         = 1.0f;
+    expected.number_epochs         = 0;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -283,7 +410,6 @@ TEST_F(Applus60Gsof, positionSigmaGsof12) {
   ASSERT_EQ(header.type, 12);
   ASSERT_EQ(header.length, 38);
 
-  using namespace trmb::gsof;
   const auto sigma = it->as<PositionSigmaInfo>();
 
   ASSERT_FLOAT_EQ(sigma.position_rms, 0.001);
@@ -298,11 +424,22 @@ TEST_F(Applus60Gsof, positionSigmaGsof12) {
   ASSERT_EQ(sigma.number_epochs, 0);
 }
 
-TEST_F(Applus60Gsof, receiverSerialNumberGsof15) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof15.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, receiverSerialNumberGsof15) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    ReceiverSerialNumber expected{};
+    expected.header.type   = GSOF_ID_15_REC_SERIAL_NUM;
+    expected.header.length = sizeof(ReceiverSerialNumber) - sizeof(Header);
+    expected.number        = 573901879;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -312,17 +449,30 @@ TEST_F(Applus60Gsof, receiverSerialNumberGsof15) {
   ASSERT_EQ(header.type, 15);
   ASSERT_EQ(header.length, 4);
 
-  using namespace trmb::gsof;
   const auto serial = it->as<ReceiverSerialNumber>();
 
   ASSERT_EQ(serial.number, 573901879);
 }
 
-TEST_F(Applus60Gsof, currentTimeGsof16) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof16.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, currentTimeGsof16) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    CurrentTime expected{};
+    expected.header.type   = GSOF_ID_16_CURR_TIME;
+    expected.header.length = sizeof(CurrentTime) - sizeof(Header);
+    expected.gps_ms_week   = 162117007;
+    expected.gps_week      = 2225;
+    expected.utc_offset    = 18;
+    expected.flags         = 0b0000'0011;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -332,7 +482,6 @@ TEST_F(Applus60Gsof, currentTimeGsof16) {
   ASSERT_EQ(header.type, 16);
   ASSERT_EQ(header.length, 9);
 
-  using namespace trmb::gsof;
   const auto time = it->as<CurrentTime>();
 
   ASSERT_EQ(time.gps_ms_week, 162117007u);
@@ -343,11 +492,48 @@ TEST_F(Applus60Gsof, currentTimeGsof16) {
   ASSERT_TRUE(time.isUtcOffsetValid());
 }
 
-TEST_F(Applus60Gsof, attitudeInfoGsof27) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof27.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, attitudeInfoGsof27) {
+  using namespace trmb::gsof;
+
+  constexpr uint8_t k_length_with_variance = 70;
+
+  const auto record = [] {
+    // AttitudeInfo has an optional trailing variance block so it cannot be memcpy'd as a whole struct.
+    std::vector<std::byte> message;
+    const auto append = [&message](auto value) {
+      if constexpr (sizeof(value) > 1) {
+        byteswapInPlace(&value);
+      }
+      const auto *bytes = reinterpret_cast<const std::byte *>(&value);
+      message.insert(message.end(), bytes, bytes + sizeof(value));
+    };
+
+    append(static_cast<uint8_t>(GSOF_ID_27_ATTITUDE));
+    append(k_length_with_variance);
+    append(static_cast<uint32_t>(162629000));
+    append(static_cast<uint8_t>(0b0000'1111));
+    append(static_cast<uint8_t>(27));                                    // num svs
+    append(static_cast<uint8_t>(Mode::CalcMode::RTK_FIX));               // calc mode
+    append(static_cast<uint8_t>(0));                                     // reserved
+    append(-6.92433215936082754188296561892E-3);                         // pitch
+    append(3.131870495343419);                                           // yaw
+    append(3.135750624153477);                                           // roll
+    append(0.0);                                                         // master slave range
+    append(static_cast<uint16_t>(10));                                   // pdop
+    append(0.000003936937f);                                             // pitch variance
+    append(0.0000271099088f);                                            // yaw variance
+    append(0.00000382736971f);                                           // roll variance
+    append(0.0f);                                                        // pitch-yaw covariance
+    append(0.0f);                                                        // pitch-roll covariance
+    append(0.0f);                                                        // yaw-roll covariance
+    append(0.0f);                                                        // master slave range variance
+
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -355,9 +541,8 @@ TEST_F(Applus60Gsof, attitudeInfoGsof27) {
 
   const auto &header = it->getHeader();
   ASSERT_EQ(header.type, 27);
-  ASSERT_EQ(header.length, 70);
+  ASSERT_EQ(header.length, k_length_with_variance);
 
-  using namespace trmb::gsof;
   const auto attitude = it->as<AttitudeInfo>();
 
   ASSERT_EQ(attitude.gps_time, 162629000u);
@@ -386,11 +571,36 @@ TEST_F(Applus60Gsof, attitudeInfoGsof27) {
   ASSERT_FLOAT_EQ(attitude.variance->master_slave_range, 0.0);
 }
 
-TEST_F(Applus60Gsof, allSvBriefInfoGsof33) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof33.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, allSvBriefInfoGsof33) {
+  using namespace trmb::gsof;
+
+  constexpr std::size_t k_num_svs                                    = 4;
+  const std::array<uint8_t, k_num_svs> expected_prn                  = {0x0b, 0x17, 0x03, 0x29};
+  const std::array<uint8_t, k_num_svs> sv_system                     = {0, 2, 3, 5};
+  const std::array<SatelliteType, k_num_svs> expected_satellite_type = {SatelliteType::GPS, SatelliteType::GLONASS,
+                                                                       SatelliteType::GALILEO, SatelliteType::BEIDOU};
+
+  const auto record = [&] {
+    // AllSvBrief holds a variable length satellite list so it cannot be memcpy'd as a whole struct.
+    std::vector<std::byte> message;
+    const auto append = [&message](uint8_t value) { message.push_back(static_cast<std::byte>(value)); };
+
+    append(GSOF_ID_33_ALL_SV_BRIEF);
+    append(static_cast<uint8_t>(1 + k_num_svs * sizeof(SVBriefInfo)));
+    append(k_num_svs);
+    for (std::size_t i = 0; i < k_num_svs; ++i) {
+      append(expected_prn[i]);
+      append(sv_system[i]);
+      append(0b0000'0111);  // above horizon, assigned to channel, tracked
+      append(0);
+    }
+
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -398,25 +608,13 @@ TEST_F(Applus60Gsof, allSvBriefInfoGsof33) {
 
   const auto &header = it->getHeader();
   ASSERT_EQ(header.type, 33);
-  ASSERT_EQ(header.length, 101);
+  ASSERT_EQ(header.length, 1 + k_num_svs * sizeof(SVBriefInfo));
 
-  using namespace trmb::gsof;
   const auto brief_sv_info = it->as<AllSvBrief>();
-  ASSERT_EQ(brief_sv_info.num_svs, 25);
-  ASSERT_EQ(brief_sv_info.sv_info.size(), 25ul);
-  const std::array<uint8_t, 25> expected_prn                  = {0x0b, 0x19, 0x0c, 0x17, 0x05, 0x1d, 0x0d, 0x02, 0x08,
-                                                                 0x07, 0x06, 0x14, 0x14, 0x0f, 0x03, 0x29, 0x0d, 0x20,
-                                                                 0x0f, 0x15, 0x1b, 0x07, 0x08, 0x1a, 0x1e};
-  const std::array<SatelliteType, 25> expected_satellite_type = {
-      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GLONASS,
-      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GPS,
-      SatelliteType::GLONASS, SatelliteType::GLONASS, SatelliteType::GPS,     SatelliteType::BEIDOU,
-      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GALILEO, SatelliteType::BEIDOU,
-      SatelliteType::GALILEO, SatelliteType::BEIDOU,  SatelliteType::GALILEO, SatelliteType::GALILEO,
-      SatelliteType::BEIDOU,  SatelliteType::GALILEO, SatelliteType::GALILEO, SatelliteType::GALILEO,
-      SatelliteType::BEIDOU};
+  ASSERT_EQ(brief_sv_info.num_svs, k_num_svs);
+  ASSERT_EQ(brief_sv_info.sv_info.size(), k_num_svs);
 
-  for (std::size_t i = 0; i < 25; ++i) {
+  for (std::size_t i = 0; i < k_num_svs; ++i) {
     const auto &info = brief_sv_info.sv_info[i];
     ASSERT_EQ(info.prn, expected_prn[i]);
     ASSERT_EQ(info.getSVSystemMode(), expected_satellite_type[i]);
@@ -426,11 +624,52 @@ TEST_F(Applus60Gsof, allSvBriefInfoGsof33) {
   }
 }
 
-TEST_F(Applus60Gsof, allSvDetailedInfoGsof34) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof34.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, allSvDetailedInfoGsof34) {
+  using namespace trmb::gsof;
+
+  constexpr std::size_t k_num_svs = 3;
+
+  const auto record = [] {
+    // AllSvDetailed holds a variable length satellite list so it cannot be memcpy'd as a whole struct.
+    std::vector<std::byte> message;
+    const auto append = [&message](auto value) {
+      if constexpr (sizeof(value) > 1) {
+        byteswapInPlace(&value);
+      }
+      const auto *bytes = reinterpret_cast<const std::byte *>(&value);
+      message.insert(message.end(), bytes, bytes + sizeof(value));
+    };
+
+    const auto appendSv = [&append](uint8_t prn, uint8_t sv_system, uint8_t flags1, uint8_t flags2, uint8_t elevation,
+                                    uint16_t azimuth, uint8_t snr_l1, uint8_t snr_l2, uint8_t snr_l5) {
+      append(prn);
+      append(sv_system);
+      append(flags1);
+      append(flags2);
+      append(elevation);
+      append(azimuth);
+      append(snr_l1);
+      append(snr_l2);
+      append(snr_l5);
+    };
+
+    append(static_cast<uint8_t>(GSOF_ID_34_ALL_SV_DETAIL));
+    append(static_cast<uint8_t>(1 + k_num_svs * sizeof(SVDetailedInfo)));
+    append(static_cast<uint8_t>(k_num_svs));
+
+    // GPS satellite used in the RTK solution, tracking L2 CS, L5 and L1C
+    appendSv(0x17, 0, 0b1111'1111, 0b0001'1100, 45, 180, 40, 41, 42);
+    // GLONASS-M satellite that is tracked but unused
+    appendSv(0x08, 2, 0b0000'0111, 0b0000'0100, 30, 90, 35, 36, 0);
+    // OmniSTAR satellite that is not being tracked
+    appendSv(0x1a, 10, 0, 0, 0, 0, 0, 0, 0);
+
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -438,94 +677,80 @@ TEST_F(Applus60Gsof, allSvDetailedInfoGsof34) {
 
   const auto &header = it->getHeader();
   ASSERT_EQ(header.type, 34);
-  ASSERT_EQ(header.length, 0xf1);
+  ASSERT_EQ(header.length, 1 + k_num_svs * sizeof(SVDetailedInfo));
 
-  using namespace trmb::gsof;
   const auto sv_info = it->as<AllSvDetailed>();
-  ASSERT_EQ(sv_info.num_svs, 24);
-  ASSERT_EQ(sv_info.sv_info.size(), 24ul);
-  const std::array<uint8_t, 24> expected_prn = {0x17, 0x12, 0x17, 0x05, 0x1d, 0x0d, 0x18, 0x02, 0x08, 0x01, 0x14, 0x1e,
-                                                0x14, 0x0f, 0x0d, 0x20, 0x1d, 0x21, 0x07, 0x08, 0x1a, 0x1e, 0x17, 0x14};
-  const std::array<SatelliteType, 24> expected_satellite_type = {
-      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GLONASS,  SatelliteType::GPS,
-      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GLONASS,  SatelliteType::GPS,
-      SatelliteType::GLONASS, SatelliteType::GLONASS, SatelliteType::BEIDOU,   SatelliteType::GPS,
-      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GALILEO,  SatelliteType::BEIDOU,
-      SatelliteType::BEIDOU,  SatelliteType::GALILEO, SatelliteType::GALILEO,  SatelliteType::GALILEO,
-      SatelliteType::GALILEO, SatelliteType::BEIDOU,  SatelliteType::OMNISTAR, SatelliteType::BEIDOU};
+  ASSERT_EQ(sv_info.num_svs, k_num_svs);
+  ASSERT_EQ(sv_info.sv_info.size(), k_num_svs);
 
-  const std::array<bool, 24> expected_dual_freq_tracking = {true,  true, false, false, true,  true,  false, true,
-                                                            true,  true, false, true,  false, true,  true,  false,
-                                                            false, true, true,  true,  true,  false, false, false};
+  const auto &gps = sv_info.sv_info[0];
+  ASSERT_EQ(gps.prn, 0x17);
+  ASSERT_EQ(gps.getSvType(), SatelliteType::GPS);
+  ASSERT_EQ(gps.elevation, 45);
+  ASSERT_EQ(gps.azimuth, 180);
+  ASSERT_EQ(gps.snr_L1, 40);
+  ASSERT_EQ(gps.snr_L2, 41);
+  ASSERT_EQ(gps.snr_L5, 42);
+  ASSERT_TRUE(gps.isAboveHor());
+  ASSERT_TRUE(gps.isAssignedToChannel());
+  ASSERT_TRUE(gps.isTracked());
+  ASSERT_TRUE(gps.isCurrTrackedDual());
+  ASSERT_TRUE(gps.isL1G1Freq());
+  ASSERT_TRUE(gps.isL1G2Freq());
+  ASSERT_TRUE(gps.isUsedAtCurrentPos());
+  ASSERT_TRUE(gps.isUsedInRtkSolution());
+  ASSERT_FALSE(gps.isTrackPCodeL1G1());
+  ASSERT_FALSE(gps.isTrackPCodeL2());
+  ASSERT_TRUE(gps.isTrackingCsOnL2());
+  ASSERT_TRUE(gps.isTrackingL5Signal());
+  ASSERT_TRUE(gps.isTrackingL1C());
+  ASSERT_FALSE(gps.isGlonassMSv());
+  ASSERT_FALSE(gps.isGlonassKSv());
 
-  const std::array<bool, 24> expected_l1g1_freq_reports = {true, true, true, true, true, true, true,  true,
-                                                           true, true, true, true, true, true, true,  true,
-                                                           true, true, true, true, true, true, false, true};
+  const auto &glonass = sv_info.sv_info[1];
+  ASSERT_EQ(glonass.prn, 0x08);
+  ASSERT_EQ(glonass.getSvType(), SatelliteType::GLONASS);
+  ASSERT_EQ(glonass.azimuth, 90);
+  ASSERT_TRUE(glonass.isAboveHor());
+  ASSERT_TRUE(glonass.isAssignedToChannel());
+  ASSERT_TRUE(glonass.isTracked());
+  ASSERT_FALSE(glonass.isCurrTrackedDual());
+  ASSERT_FALSE(glonass.isUsedInRtkSolution());
+  ASSERT_TRUE(glonass.isGlonassMSv());
+  ASSERT_FALSE(glonass.isGlonassKSv());
+  ASSERT_FALSE(glonass.isTrackingCsOnL2());
 
-  const std::array<bool, 24> expected_l1g2_freq_reports = {true, true, false, true, true, true, true,  true,
-                                                           true, true, true,  true, true, true, true,  true,
-                                                           true, true, true,  true, true, true, false, true};
-
-  const std::array<bool, 24> expected_used_at_current_pos = {false, true, true, true, true, true, false, true,
-                                                             false, true, true, true, true, true, true,  true,
-                                                             true,  true, true, true, true, true, false, true};
-
-  const std::array<bool, 24> expected_used_in_rtk_solution = {false, false, false, false, true,  false, false, false,
-                                                              false, false, false, false, false, false, false, false,
-                                                              true,  false, true,  false, false, false, false, false};
-
-  const std::array<bool, 24> expected_pcode_l1g1 = {false, false, false, false, false, false, false, false,
-                                                    false, false, true,  false, false, false, true,  true,
-                                                    true,  true,  true,  true,  true,  true,  false, false};
-
-  const std::array<bool, 24> expected_cs_l2_tracking = {true,  true,  false, false, true,  false, false, false,
-                                                        false, false, false, true,  false, true,  false, false,
-                                                        false, false, false, false, false, false, false, false};
-
-  const std::array<bool, 24> expected_l5_tracking = {true,  true,  false, false, false, false, false, false,
-                                                     false, false, false, true,  false, false, false, false,
-                                                     false, false, false, false, false, false, false, false};
-
-  const std::array<bool, 24> expected_glonass_mtype = {false, false, true,  false, false, false, true,  false,
-                                                       true,  true,  false, false, false, false, false, false,
-                                                       false, false, false, false, false, false, false, false};
-
-  for (std::size_t i = 0; i < 24; ++i) {
-    const auto &info = sv_info.sv_info[i];
-    ASSERT_EQ(info.prn, expected_prn[i]);
-    ASSERT_EQ(info.getSvType(), expected_satellite_type[i]);
-
-    if (info.getSvType() != SatelliteType::OMNISTAR) {
-      ASSERT_TRUE(info.isAboveHor());
-      ASSERT_TRUE(info.isAssignedToChannel());
-      ASSERT_TRUE(info.isTracked());
-    } else {
-      ASSERT_FALSE(info.isAboveHor());
-      ASSERT_FALSE(info.isAssignedToChannel());
-      ASSERT_FALSE(info.isTracked());
-    }
-
-    ASSERT_EQ(info.isCurrTrackedDual(), expected_dual_freq_tracking[i]);
-    ASSERT_EQ(info.isL1G1Freq(), expected_l1g1_freq_reports[i]);
-    ASSERT_EQ(info.isL1G2Freq(), expected_l1g2_freq_reports[i]);
-    ASSERT_EQ(info.isUsedAtCurrentPos(), expected_used_at_current_pos[i]);
-    ASSERT_EQ(info.isUsedInRtkSolution(), expected_used_in_rtk_solution[i]);
-
-    ASSERT_EQ(info.isTrackPCodeL1G1(), expected_pcode_l1g1[i]);
-    ASSERT_FALSE(info.isTrackPCodeL2());
-    ASSERT_EQ(info.isTrackingCsOnL2(), expected_cs_l2_tracking[i]) << "with i " << i << " and " << int(info.sv_system);
-    ASSERT_EQ(info.isTrackingL5Signal(), expected_l5_tracking[i]);
-
-    ASSERT_EQ(info.isGlonassMSv(), expected_glonass_mtype[i]);
-    ASSERT_FALSE(info.isGlonassKSv());
-  }
+  const auto &omnistar = sv_info.sv_info[2];
+  ASSERT_EQ(omnistar.prn, 0x1a);
+  ASSERT_EQ(omnistar.getSvType(), SatelliteType::OMNISTAR);
+  ASSERT_FALSE(omnistar.isAboveHor());
+  ASSERT_FALSE(omnistar.isAssignedToChannel());
+  ASSERT_FALSE(omnistar.isTracked());
 }
 
-TEST_F(Applus60Gsof, receivedBaseInfoGsof35) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof35.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, receivedBaseInfoGsof35) {
+  using namespace trmb::gsof;
+
+  const std::array<char, 8> expected_name = {'R', 'T', 'C', 'M', '0', '0', '0', '0'};
+
+  const auto record = [&expected_name] {
+    ReceivedBaseInfo expected{};
+    expected.header.type        = GSOF_ID_35_RECEIVED_BASE_INFO;
+    expected.header.length      = sizeof(ReceivedBaseInfo) - sizeof(Header);
+    expected.flags              = 0b0000'1000;  // version 0, base info valid
+    expected.name               = expected_name;
+    expected.id                 = 0;
+    expected.base_lla.latitude  = 0.7630018859478892;
+    expected.base_lla.longitude = -1.385119519554126;
+    expected.base_lla.altitude  = 101.22497844472646;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -535,10 +760,8 @@ TEST_F(Applus60Gsof, receivedBaseInfoGsof35) {
   ASSERT_EQ(header.type, 35);
   ASSERT_EQ(header.length, 35);
 
-  using namespace trmb::gsof;
   const auto base_info = it->as<ReceivedBaseInfo>();
 
-  const std::array<char, 8> expected_name = {'R', 'T', 'C', 'M', '0', '0', '0', '0'};
   ASSERT_EQ(expected_name, base_info.name);
   ASSERT_EQ(base_info.getVersionNumber(), 0);
   ASSERT_EQ(base_info.id, 0);
@@ -549,11 +772,23 @@ TEST_F(Applus60Gsof, receivedBaseInfoGsof35) {
   ASSERT_DOUBLE_EQ(base_info.base_lla.altitude, 101.22497844472646);
 }
 
-TEST_F(Applus60Gsof, batteryMemoryInfoGsof37) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof37.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, batteryMemoryInfoGsof37) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    BatteryMemoryInfo expected{};
+    expected.header.type    = GSOF_ID_37_BATTERY_MEM_INFO;
+    expected.header.length  = sizeof(BatteryMemoryInfo) - sizeof(Header);
+    expected.battery_cap    = 100;
+    expected.remaining_time = 1343.1210074074074;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -563,18 +798,50 @@ TEST_F(Applus60Gsof, batteryMemoryInfoGsof37) {
   ASSERT_EQ(header.type, 37);
   ASSERT_EQ(header.length, 10);
 
-  using namespace trmb::gsof;
   const auto battery = it->as<BatteryMemoryInfo>();
 
   ASSERT_EQ(battery.battery_cap, 100);
   ASSERT_DOUBLE_EQ(battery.remaining_time, 1343.1210074074074);
 }
 
-TEST_F(Applus60Gsof, positionTypeGsof38) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof38.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, positionTypeGsof38) {
+  using namespace trmb::gsof;
+
+  constexpr uint8_t k_length_up_to_fw4_94 = 26;
+
+  const auto record = [] {
+    // PositionTypeInformation can grow with firmware versions so it cannot be memcpy'd as a whole struct.
+    std::vector<std::byte> message;
+    const auto append = [&message](auto value) {
+      if constexpr (sizeof(value) > 1) {
+        byteswapInPlace(&value);
+      }
+      const auto *bytes = reinterpret_cast<const std::byte *>(&value);
+      message.insert(message.end(), bytes, bytes + sizeof(value));
+    };
+
+    append(static_cast<uint8_t>(GSOF_ID_38_POSITION_TYPE_INFO));
+    append(k_length_up_to_fw4_94);
+    append(1.0f);                                             // error scale
+    append(static_cast<uint8_t>(0b0000'1010));                // RTK fix, initialization integrity check passed
+    append(static_cast<uint8_t>(0));                          // rtk condition
+    append(0.0f);                                             // correction age
+    append(static_cast<uint8_t>(0));                          // network flags
+    append(static_cast<uint8_t>(0));                          // network flags 2
+    append(static_cast<uint8_t>(0));                          // frame flag
+    append(static_cast<uint16_t>(0));                         // itrf epoch
+    append(static_cast<uint8_t>(0));                          // tectonic plate
+    append(int32_t{0});                                       // rtx ram subscription minutes left
+    append(static_cast<uint8_t>(0));                          // pole wobble status flag
+    append(0.0f);                                             // pole wobble distance
+    append(static_cast<uint8_t>(PositionFix::k_ins_rtk));     // position fix type
+
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -582,9 +849,8 @@ TEST_F(Applus60Gsof, positionTypeGsof38) {
 
   const auto &header = it->getHeader();
   ASSERT_EQ(header.type, 38);
-  ASSERT_EQ(header.length, 26);
+  ASSERT_EQ(header.length, k_length_up_to_fw4_94);
 
-  using namespace trmb::gsof;
   const auto type = it->as<PositionTypeInformation>();
   ASSERT_EQ(type.unparsed_bytes.size(), 0ul);
 
@@ -617,11 +883,47 @@ TEST_F(Applus60Gsof, positionTypeGsof38) {
   ASSERT_EQ(type.getPositionFixType(), PositionFix::k_ins_rtk);
 }
 
-TEST_F(Applus60Gsof, lbandStatusGsof40) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof40.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, lbandStatusGsof40) {
+  using namespace trmb::gsof;
+
+  const std::array<char, 5> expected_name = {'R', 'T', 'X', 'N', 'A'};
+
+  const auto record = [&expected_name] {
+    LbandStatusInfo expected{};
+    expected.header.type   = GSOF_ID_40_LBAND_STATUS;
+    expected.header.length = sizeof(LbandStatusInfo) - sizeof(Header);
+    expected.satellite_name = expected_name;
+    // This frequency and baud rate were taken from https://positioningservices.trimble.com/resources/sat/ it is the
+    // North America RTX beam frequency and baud
+    expected.nominal_sat_freq              = 1555.8080f;
+    expected.sat_bit_rate                  = 2400;
+    expected.c_no                          = 47.0f;
+    expected.hpxp_sub_engine               = static_cast<uint8_t>(omnistar::HpXpEngine::k_hp);
+    expected.hpxp_library_mode             = static_cast<uint8_t>(omnistar::HpXpLibraryMode::k_not_active);
+    expected.vbs_library_mode              = static_cast<uint8_t>(omnistar::VbsLibraryMode::k_not_active);
+    expected.beam_mode                     = static_cast<uint8_t>(omnistar::BeamMode::k_tracking);
+    expected.omnistar_motion               = static_cast<uint8_t>(omnistar::MotionState::k_unknown);
+    expected.sigma_hor_threshold           = 0.3f;
+    expected.sigma_ver_threshold           = 0.3f;
+    expected.nmea_enc_state                = static_cast<uint8_t>(omnistar::NmeaEncryptionState::k_off);
+    expected.i_q_ratio                     = 5.08325863f;
+    expected.estimated_bit_error_rate      = 0.000029838955f;
+    expected.total_messages                = 8790;
+    expected.total_unique_words_with_errors = 3265;
+    expected.total_bad_unique_word_bits    = 9939;
+    expected.total_num_viterbi_symbols     = 71453248;
+    expected.num_corrected_viterbi_symbols = 1147334;
+    expected.num_bad_messages              = 39;
+    expected.meas_frequency_valid_flag     = 1;
+    expected.measured_frequency            = 1555808020.7808383;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -631,18 +933,14 @@ TEST_F(Applus60Gsof, lbandStatusGsof40) {
   ASSERT_EQ(header.type, 40);
   ASSERT_EQ(header.length, 70);
 
-  using namespace trmb::gsof;
   const auto lband_status = it->as<LbandStatusInfo>();
 
-  const std::array<char, 5> expected_name = {'R', 'T', 'X', 'N', 'A'};
   ASSERT_EQ(lband_status.satellite_name, expected_name);
 
-  // This frequency and baud rate were taken from https://positioningservices.trimble.com/resources/sat/ it is the
-  // North America RTX beam frequency and baud
   ASSERT_FLOAT_EQ(lband_status.nominal_sat_freq, 1555.8080f);
   ASSERT_EQ(lband_status.sat_bit_rate, 2400);
 
-  ASSERT_NEAR(static_cast<double>(lband_status.c_no), 47.0, 0.1);  // GUI just says 47
+  ASSERT_NEAR(static_cast<double>(lband_status.c_no), 47.0, 0.1);
   ASSERT_EQ(lband_status.getHpXpEngine(), omnistar::HpXpEngine::k_hp);
   ASSERT_EQ(lband_status.getHpXpLibraryMode(), omnistar::HpXpLibraryMode::k_not_active);
   ASSERT_EQ(lband_status.getVbsLibraryMode(), omnistar::VbsLibraryMode::k_not_active);
@@ -665,11 +963,27 @@ TEST_F(Applus60Gsof, lbandStatusGsof40) {
   ASSERT_TRUE(lband_status.isMeasuredFrequencyValid());
   ASSERT_DOUBLE_EQ(lband_status.measured_frequency, 1555808020.7808383);
 }
-TEST_F(Applus60Gsof, basePositionQualityGsof41) {
-  auto maybe_gsof_parser = openPcap("applus60_gsof41.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(GsofParsingTest, basePositionQualityGsof41) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    BasePositionAndQualityIndicator expected{};
+    expected.header.type     = GSOF_ID_41_BASE_POSITION_QUALITY;
+    expected.header.length   = sizeof(BasePositionAndQualityIndicator) - sizeof(Header);
+    expected.gps_time_ms     = 328103007;
+    expected.gps_week_number = 2225;
+    expected.llh.latitude    = 0.7630018859478892;
+    expected.llh.longitude   = -1.385119519554126;
+    expected.llh.altitude    = 101.22497844472646;
+    expected.quality         = static_cast<uint8_t>(BaseQuality::k_omnistar_xp_hp_or_rtk_float);
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -679,7 +993,6 @@ TEST_F(Applus60Gsof, basePositionQualityGsof41) {
   ASSERT_EQ(header.type, 41);
   ASSERT_EQ(header.length, 31);
 
-  using namespace trmb::gsof;
   const auto base_qual = it->as<BasePositionAndQualityIndicator>();
 
   ASSERT_EQ(base_qual.gps_time_ms, 328103007u);
@@ -691,15 +1004,42 @@ TEST_F(Applus60Gsof, basePositionQualityGsof41) {
 }
 
 TEST(GsofParsingTest, fullNavigationInfoGsof49) {
-  network::NonOwningBuffer payload{nullptr, 0};
-  network::PcapReader pcap_reader("apx_18_fullnavinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
-                                  network::ProtocolType::TCP);
-  ASSERT_TRUE(static_cast<bool>(pcap_reader));
-  ASSERT_TRUE(pcap_reader.readSingle(&payload));
-  ASSERT_NE(payload.data, nullptr);
+  using namespace trmb::gsof;
 
-  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  const auto record = [] {
+    NavigationSolution expected{};
+    expected.header.type          = GSOF_ID_49_INS_FULL_NAV;
+    expected.header.length        = sizeof(NavigationSolution) - sizeof(Header);
+    expected.gps_time.week        = 2080;  // week of nov 17th 2019
+    expected.gps_time.time_msec   = 162117007;
+    expected.status.imu_alignment = static_cast<uint8_t>(Status::ImuAlignmentStatus::FULL_NAV);
+    expected.status.gnss          = static_cast<uint8_t>(Status::GnssStatus::FIXED_RTK_MODE);
+    // Guesstimated Google Maps lat long of Trimble Applanix Richmond Hill - Canada office
+    expected.lla.latitude         = 43.86;
+    expected.lla.longitude        = -79.38;
+    expected.lla.altitude         = 168.25;
+    expected.velocity.north       = 1.5f;
+    expected.velocity.east        = -0.25f;
+    expected.velocity.down        = 0.125f;
+    expected.total_speed          = 1.5207f;
+    expected.attitude.roll        = 0.5;
+    expected.attitude.pitch       = -1.25;
+    expected.attitude.heading     = 91.75;
+    expected.track_angle          = 92.5;
+    expected.angular_rate.roll    = 0.01f;
+    expected.angular_rate.pitch   = -0.02f;
+    expected.angular_rate.heading = 0.03f;
+    expected.acceleration.x       = 0.1f;
+    expected.acceleration.y       = -0.2f;
+    expected.acceleration.z       = 9.81f;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
 
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
@@ -707,112 +1047,201 @@ TEST(GsofParsingTest, fullNavigationInfoGsof49) {
   ASSERT_EQ(it->getHeader().type, 0x31);
   ASSERT_EQ(it->getHeader().length, 0x68);  // Read our ICD not the GSOF stuff on the web
 
-  using namespace trmb::gsof;
-  auto solution = it->as<NavigationSolution>();
-  ASSERT_EQ(solution.gps_time.week, 2080);  // week of nov 17th 2019
-  // Guesstimated Google Maps lat long of Trimble Applanix Richmond Hill - Canada office 😄
-  ASSERT_NEAR(solution.lla.latitude, 43.86, 1e-2);
-  ASSERT_NEAR(solution.lla.longitude, -79.38, 1e-2);
+  const auto solution = it->as<NavigationSolution>();
+  ASSERT_EQ(solution.gps_time.week, 2080);
+  ASSERT_EQ(solution.gps_time.time_msec, 162117007u);
+  ASSERT_DOUBLE_EQ(solution.lla.latitude, 43.86);
+  ASSERT_DOUBLE_EQ(solution.lla.longitude, -79.38);
+  ASSERT_DOUBLE_EQ(solution.lla.altitude, 168.25);
 
-  ASSERT_NE(solution.status.getImuAlignmentStatus(), Status::ImuAlignmentStatus::UNKNOWN);
-  ASSERT_NE(solution.status.getGnssStatus(), Status::GnssStatus::UNKNOWN);
+  ASSERT_EQ(solution.status.getImuAlignmentStatus(), Status::ImuAlignmentStatus::FULL_NAV);
+  ASSERT_EQ(solution.status.getGnssStatus(), Status::GnssStatus::FIXED_RTK_MODE);
+
+  ASSERT_FLOAT_EQ(solution.velocity.north, 1.5f);
+  ASSERT_FLOAT_EQ(solution.velocity.east, -0.25f);
+  ASSERT_FLOAT_EQ(solution.velocity.down, 0.125f);
+  ASSERT_FLOAT_EQ(solution.total_speed, 1.5207f);
+
+  ASSERT_DOUBLE_EQ(solution.attitude.roll, 0.5);
+  ASSERT_DOUBLE_EQ(solution.attitude.pitch, -1.25);
+  ASSERT_DOUBLE_EQ(solution.attitude.heading, 91.75);
+  ASSERT_DOUBLE_EQ(solution.track_angle, 92.5);
+
+  ASSERT_FLOAT_EQ(solution.angular_rate.roll, 0.01f);
+  ASSERT_FLOAT_EQ(solution.angular_rate.pitch, -0.02f);
+  ASSERT_FLOAT_EQ(solution.angular_rate.heading, 0.03f);
+
+  ASSERT_FLOAT_EQ(solution.acceleration.x, 0.1f);
+  ASSERT_FLOAT_EQ(solution.acceleration.y, -0.2f);
+  ASSERT_FLOAT_EQ(solution.acceleration.z, 9.81f);
 }
 
 TEST(GsofParsingTest, fullNavigationRmsGsof50) {
-  network::NonOwningBuffer payload{nullptr, 0};
-  network::PcapReader pcap_reader("apx_18_fullrmsinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
-                                  network::ProtocolType::TCP);
-  ASSERT_TRUE(static_cast<bool>(pcap_reader));
-  ASSERT_TRUE(pcap_reader.readSingle(&payload));
-  ASSERT_NE(payload.data, nullptr);
+  using namespace trmb::gsof;
 
-  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  const auto record = [] {
+    NavigationPerformance expected{};
+    expected.header.type          = GSOF_ID_50_INS_RMS;
+    expected.header.length        = sizeof(NavigationPerformance) - sizeof(Header);
+    expected.gps_time.week        = 2080;
+    expected.gps_time.time_msec   = 162117007;
+    expected.status.imu_alignment = static_cast<uint8_t>(Status::ImuAlignmentStatus::FULL_NAV);
+    expected.status.gnss          = static_cast<uint8_t>(Status::GnssStatus::FIXED_RTK_MODE);
+    expected.position_rms.north   = 0.015f;
+    expected.position_rms.east    = 0.014f;
+    expected.position_rms.down    = 0.025f;
+    expected.velocity_rms.north   = 0.005f;
+    expected.velocity_rms.east    = 0.004f;
+    expected.velocity_rms.down    = 0.007f;
+    expected.attitude_rms.roll    = 0.011f;
+    expected.attitude_rms.pitch   = 0.012f;
+    expected.attitude_rms.heading = 0.045f;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
+  ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
+
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
 
-  auto it = message_parser.begin();
-  using namespace trmb::gsof;
-  auto rms = it->as<NavigationPerformance>();
+  auto it        = message_parser.begin();
+  const auto rms = it->as<NavigationPerformance>();
   ASSERT_EQ(rms.gps_time.week, 2080);
+  ASSERT_EQ(rms.gps_time.time_msec, 162117007u);
 
-  ASSERT_NE(rms.status.getImuAlignmentStatus(), Status::ImuAlignmentStatus::UNKNOWN);
-  ASSERT_NE(rms.status.getGnssStatus(), Status::GnssStatus::UNKNOWN);
+  ASSERT_EQ(rms.status.getImuAlignmentStatus(), Status::ImuAlignmentStatus::FULL_NAV);
+  ASSERT_EQ(rms.status.getGnssStatus(), Status::GnssStatus::FIXED_RTK_MODE);
+
+  ASSERT_FLOAT_EQ(rms.position_rms.north, 0.015f);
+  ASSERT_FLOAT_EQ(rms.position_rms.east, 0.014f);
+  ASSERT_FLOAT_EQ(rms.position_rms.down, 0.025f);
+  ASSERT_FLOAT_EQ(rms.velocity_rms.north, 0.005f);
+  ASSERT_FLOAT_EQ(rms.velocity_rms.east, 0.004f);
+  ASSERT_FLOAT_EQ(rms.velocity_rms.down, 0.007f);
+  ASSERT_FLOAT_EQ(rms.attitude_rms.roll, 0.011f);
+  ASSERT_FLOAT_EQ(rms.attitude_rms.pitch, 0.012f);
+  ASSERT_FLOAT_EQ(rms.attitude_rms.heading, 0.045f);
 
   ++it;
   ASSERT_EQ(it, message_parser.end());
 }
 
 TEST(GsofParsingTest, dmiRawDataGsof52) {
-  network::NonOwningBuffer payload{nullptr, 0};
-  network::PcapReader pcap_reader("apx_18_gsof52_dmirawdata_single.pcap", k_apx18_ip_addr, k_apx18_port,
-                                  network::ProtocolType::TCP);
-  ASSERT_TRUE(static_cast<bool>(pcap_reader));
-  ASSERT_TRUE(pcap_reader.readSingle(&payload));
-  ASSERT_NE(payload.data, nullptr);
+  using namespace trmb::gsof;
 
-  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  const auto record = [] {
+    DmiRawData expected{};
+    expected.header.type        = GSOF_ID_52_DMI_RAW_DATA;
+    expected.header.length      = sizeof(DmiRawData) - sizeof(Header);
+    expected.gps_time.week      = 2122;
+    expected.gps_time.time_msec = 162117007;
+    expected.num_raw_meas       = 10;
+    expected.time_offset        = 25;
+    expected.abs_dist_count     = 123456;
+    expected.ud_dist_count      = -789;
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
+  ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
+
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
 
-  auto it = message_parser.begin();
-  using namespace trmb::gsof;
-  auto dmiRawData = it->as<DmiRawData>();
-  ASSERT_EQ(dmiRawData.gps_time.week, 2122);
-  ASSERT_EQ(dmiRawData.num_raw_meas, 10);
-  ASSERT_EQ(dmiRawData.time_offset, 0);
-  ASSERT_EQ(dmiRawData.abs_dist_count, 0ul);
-  ASSERT_EQ(dmiRawData.ud_dist_count, 0);
+  auto it                 = message_parser.begin();
+  const auto dmi_raw_data = it->as<DmiRawData>();
+  ASSERT_EQ(dmi_raw_data.gps_time.week, 2122);
+  ASSERT_EQ(dmi_raw_data.gps_time.time_msec, 162117007u);
+  ASSERT_EQ(dmi_raw_data.num_raw_meas, 10);
+  ASSERT_EQ(dmi_raw_data.time_offset, 25);
+  ASSERT_EQ(dmi_raw_data.abs_dist_count, 123456ul);
+  ASSERT_EQ(dmi_raw_data.ud_dist_count, -789);
 
   ++it;
   ASSERT_EQ(it, message_parser.end());
 }
 
 TEST(GsofParsingTest, iterator) {
-  network::NonOwningBuffer payload{nullptr, 0};
-  network::PcapReader pcap_reader("apx_18_fullnavinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
-                                  network::ProtocolType::TCP);
-  ASSERT_TRUE(static_cast<bool>(pcap_reader));
-  ASSERT_TRUE(pcap_reader.readSingle(&payload));
-  ASSERT_NE(payload.data, nullptr);
+  using namespace trmb::gsof;
 
-  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  const auto record = [] {
+    NavigationSolution solution{};
+    solution.header.type   = GSOF_ID_49_INS_FULL_NAV;
+    solution.header.length = sizeof(NavigationSolution) - sizeof(Header);
+    solution.gps_time.week = 2080;
 
-  using namespace trmb;
+    NavigationPerformance rms{};
+    rms.header.type   = GSOF_ID_50_INS_RMS;
+    rms.header.length = sizeof(NavigationPerformance) - sizeof(Header);
+    rms.gps_time.week = 2080;
+
+    // A single GENOUT record can carry back to back messages
+    auto messages           = serialize(solution);
+    const auto rms_messages = serialize(rms);
+    messages.insert(messages.end(), rms_messages.begin(), rms_messages.end());
+
+    return makeGenoutRecord(messages.data(), messages.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
+  ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
+
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
   auto it = message_parser.begin();
-  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_49_INS_FULL_NAV);
+  ASSERT_EQ(it->getHeader().type, GSOF_ID_49_INS_FULL_NAV);
   ++it;
-  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_50_INS_RMS);
+  ASSERT_EQ(it->getHeader().type, GSOF_ID_50_INS_RMS);
   ++it;
   ASSERT_EQ(it, message_parser.end());
 }
 
 TEST(GsofParsingTest, streamParser) {
-  network::NonOwningBuffer payload{nullptr, 0};
-  network::PcapReader pcap_reader("apx_18_fullnavinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
-                                  network::ProtocolType::TCP);
-  ASSERT_TRUE(static_cast<bool>(pcap_reader));
-  ASSERT_TRUE(pcap_reader.readSingle(&payload));
-  ASSERT_NE(payload.data, nullptr);
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    NavigationSolution solution{};
+    solution.header.type   = GSOF_ID_49_INS_FULL_NAV;
+    solution.header.length = sizeof(NavigationSolution) - sizeof(Header);
+    solution.gps_time.week = 2080;
+
+    NavigationPerformance rms{};
+    rms.header.type   = GSOF_ID_50_INS_RMS;
+    rms.header.length = sizeof(NavigationPerformance) - sizeof(Header);
+    rms.gps_time.week = 2080;
+
+    auto messages           = serialize(solution);
+    const auto rms_messages = serialize(rms);
+    messages.insert(messages.end(), rms_messages.begin(), rms_messages.end());
+
+    return makeGenoutRecord(messages.data(), messages.size());
+  }();
 
   std::random_device rd;
   std::mt19937 gen(rd());
   std::uniform_int_distribution<> distribution(1, 512);
 
   std::array<std::uint8_t, 512> buf{};
-  trmb::gsof::StreamPageParser stream_parser;
+  StreamPageParser stream_parser;
   std::optional<std::vector<std::byte>> result = std::nullopt;
 
-  stream_parser.registerGsofPageFoundCallback([&payload, &result](const std::vector<std::byte> &page) {
-    ASSERT_EQ(page.size(), payload.length);
+  stream_parser.registerGsofPageFoundCallback([&record, &result](const std::vector<std::byte> &page) {
+    ASSERT_EQ(page.size(), record.size());
     result = page;
   });
 
   // Pass on random sized buffers to the stream parser
-  for (std::size_t bytes_read = 0; bytes_read < payload.length;) {
-    int bytes_to_read = std::min(distribution(gen), static_cast<int>(payload.length - bytes_read));
-    std::memcpy(buf.data(), payload.data + bytes_read, bytes_to_read);
+  for (std::size_t bytes_read = 0; bytes_read < record.size();) {
+    int bytes_to_read = std::min(distribution(gen), static_cast<int>(record.size() - bytes_read));
+    std::memcpy(buf.data(), record.data() + bytes_read, bytes_to_read);
     bytes_read += bytes_to_read;
 
     stream_parser.readSome(buf.data(), bytes_to_read);
@@ -821,17 +1250,16 @@ TEST(GsofParsingTest, streamParser) {
   // Now prove that you can parse the resulting vector of bytes using the packet parser
   ASSERT_TRUE(result.has_value());  // For -Wmaybe-uninitialized
 
-  PacketParser gsof_parser(result->data(), result->size());
+  PublicPacketParser gsof_parser(result->data(), result->size());
   ASSERT_TRUE(gsof_parser.isValid());
   ASSERT_TRUE(gsof_parser.isSupported());
 
-  using namespace trmb;
   auto message_parser = gsof_parser.getMessageParser();
   ASSERT_TRUE(message_parser.isValid());
   auto it = message_parser.begin();
-  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_49_INS_FULL_NAV);
+  ASSERT_EQ(it->getHeader().type, GSOF_ID_49_INS_FULL_NAV);
   ++it;
-  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_50_INS_RMS);
+  ASSERT_EQ(it->getHeader().type, GSOF_ID_50_INS_RMS);
   ++it;
   ASSERT_EQ(it, message_parser.end());
 }

--- a/trimble_driver/test/test_gsof.cpp
+++ b/trimble_driver/test/test_gsof.cpp
@@ -512,21 +512,21 @@ TEST(GsofParsingTest, attitudeInfoGsof27) {
     append(k_length_with_variance);
     append(static_cast<uint32_t>(162629000));
     append(static_cast<uint8_t>(0b0000'1111));
-    append(static_cast<uint8_t>(27));                                    // num svs
-    append(static_cast<uint8_t>(Mode::CalcMode::RTK_FIX));               // calc mode
-    append(static_cast<uint8_t>(0));                                     // reserved
-    append(-6.92433215936082754188296561892E-3);                         // pitch
-    append(3.131870495343419);                                           // yaw
-    append(3.135750624153477);                                           // roll
-    append(0.0);                                                         // master slave range
-    append(static_cast<uint16_t>(10));                                   // pdop
-    append(0.000003936937f);                                             // pitch variance
-    append(0.0000271099088f);                                            // yaw variance
-    append(0.00000382736971f);                                           // roll variance
-    append(0.0f);                                                        // pitch-yaw covariance
-    append(0.0f);                                                        // pitch-roll covariance
-    append(0.0f);                                                        // yaw-roll covariance
-    append(0.0f);                                                        // master slave range variance
+    append(static_cast<uint8_t>(27));                       // num svs
+    append(static_cast<uint8_t>(Mode::CalcMode::RTK_FIX));  // calc mode
+    append(static_cast<uint8_t>(0));                        // reserved
+    append(-6.92433215936082754188296561892E-3);            // pitch
+    append(3.131870495343419);                              // yaw
+    append(3.135750624153477);                              // roll
+    append(0.0);                                            // master slave range
+    append(static_cast<uint16_t>(10));                      // pdop
+    append(0.000003936937f);                                // pitch variance
+    append(0.0000271099088f);                               // yaw variance
+    append(0.00000382736971f);                              // roll variance
+    append(0.0f);                                           // pitch-yaw covariance
+    append(0.0f);                                           // pitch-roll covariance
+    append(0.0f);                                           // yaw-roll covariance
+    append(0.0f);                                           // master slave range variance
 
     return makeGenoutRecord(message.data(), message.size());
   }();
@@ -578,7 +578,7 @@ TEST(GsofParsingTest, allSvBriefInfoGsof33) {
   const std::array<uint8_t, k_num_svs> expected_prn                  = {0x0b, 0x17, 0x03, 0x29};
   const std::array<uint8_t, k_num_svs> sv_system                     = {0, 2, 3, 5};
   const std::array<SatelliteType, k_num_svs> expected_satellite_type = {SatelliteType::GPS, SatelliteType::GLONASS,
-                                                                       SatelliteType::GALILEO, SatelliteType::BEIDOU};
+                                                                        SatelliteType::GALILEO, SatelliteType::BEIDOU};
 
   const auto record = [&] {
     // AllSvBrief holds a variable length satellite list so it cannot be memcpy'd as a whole struct.
@@ -822,19 +822,19 @@ TEST(GsofParsingTest, positionTypeGsof38) {
 
     append(static_cast<uint8_t>(GSOF_ID_38_POSITION_TYPE_INFO));
     append(k_length_up_to_fw4_94);
-    append(1.0f);                                             // error scale
-    append(static_cast<uint8_t>(0b0000'1010));                // RTK fix, initialization integrity check passed
-    append(static_cast<uint8_t>(0));                          // rtk condition
-    append(0.0f);                                             // correction age
-    append(static_cast<uint8_t>(0));                          // network flags
-    append(static_cast<uint8_t>(0));                          // network flags 2
-    append(static_cast<uint8_t>(0));                          // frame flag
-    append(static_cast<uint16_t>(0));                         // itrf epoch
-    append(static_cast<uint8_t>(0));                          // tectonic plate
-    append(int32_t{0});                                       // rtx ram subscription minutes left
-    append(static_cast<uint8_t>(0));                          // pole wobble status flag
-    append(0.0f);                                             // pole wobble distance
-    append(static_cast<uint8_t>(PositionFix::k_ins_rtk));     // position fix type
+    append(1.0f);                                          // error scale
+    append(static_cast<uint8_t>(0b0000'1010));             // RTK fix, initialization integrity check passed
+    append(static_cast<uint8_t>(0));                       // rtk condition
+    append(0.0f);                                          // correction age
+    append(static_cast<uint8_t>(0));                       // network flags
+    append(static_cast<uint8_t>(0));                       // network flags 2
+    append(static_cast<uint8_t>(0));                       // frame flag
+    append(static_cast<uint16_t>(0));                      // itrf epoch
+    append(static_cast<uint8_t>(0));                       // tectonic plate
+    append(int32_t{0});                                    // rtx ram subscription minutes left
+    append(static_cast<uint8_t>(0));                       // pole wobble status flag
+    append(0.0f);                                          // pole wobble distance
+    append(static_cast<uint8_t>(PositionFix::k_ins_rtk));  // position fix type
 
     return makeGenoutRecord(message.data(), message.size());
   }();
@@ -890,32 +890,32 @@ TEST(GsofParsingTest, lbandStatusGsof40) {
 
   const auto record = [&expected_name] {
     LbandStatusInfo expected{};
-    expected.header.type   = GSOF_ID_40_LBAND_STATUS;
-    expected.header.length = sizeof(LbandStatusInfo) - sizeof(Header);
+    expected.header.type    = GSOF_ID_40_LBAND_STATUS;
+    expected.header.length  = sizeof(LbandStatusInfo) - sizeof(Header);
     expected.satellite_name = expected_name;
     // This frequency and baud rate were taken from https://positioningservices.trimble.com/resources/sat/ it is the
     // North America RTX beam frequency and baud
-    expected.nominal_sat_freq              = 1555.8080f;
-    expected.sat_bit_rate                  = 2400;
-    expected.c_no                          = 47.0f;
-    expected.hpxp_sub_engine               = static_cast<uint8_t>(omnistar::HpXpEngine::k_hp);
-    expected.hpxp_library_mode             = static_cast<uint8_t>(omnistar::HpXpLibraryMode::k_not_active);
-    expected.vbs_library_mode              = static_cast<uint8_t>(omnistar::VbsLibraryMode::k_not_active);
-    expected.beam_mode                     = static_cast<uint8_t>(omnistar::BeamMode::k_tracking);
-    expected.omnistar_motion               = static_cast<uint8_t>(omnistar::MotionState::k_unknown);
-    expected.sigma_hor_threshold           = 0.3f;
-    expected.sigma_ver_threshold           = 0.3f;
-    expected.nmea_enc_state                = static_cast<uint8_t>(omnistar::NmeaEncryptionState::k_off);
-    expected.i_q_ratio                     = 5.08325863f;
-    expected.estimated_bit_error_rate      = 0.000029838955f;
-    expected.total_messages                = 8790;
+    expected.nominal_sat_freq               = 1555.8080f;
+    expected.sat_bit_rate                   = 2400;
+    expected.c_no                           = 47.0f;
+    expected.hpxp_sub_engine                = static_cast<uint8_t>(omnistar::HpXpEngine::k_hp);
+    expected.hpxp_library_mode              = static_cast<uint8_t>(omnistar::HpXpLibraryMode::k_not_active);
+    expected.vbs_library_mode               = static_cast<uint8_t>(omnistar::VbsLibraryMode::k_not_active);
+    expected.beam_mode                      = static_cast<uint8_t>(omnistar::BeamMode::k_tracking);
+    expected.omnistar_motion                = static_cast<uint8_t>(omnistar::MotionState::k_unknown);
+    expected.sigma_hor_threshold            = 0.3f;
+    expected.sigma_ver_threshold            = 0.3f;
+    expected.nmea_enc_state                 = static_cast<uint8_t>(omnistar::NmeaEncryptionState::k_off);
+    expected.i_q_ratio                      = 5.08325863f;
+    expected.estimated_bit_error_rate       = 0.000029838955f;
+    expected.total_messages                 = 8790;
     expected.total_unique_words_with_errors = 3265;
-    expected.total_bad_unique_word_bits    = 9939;
-    expected.total_num_viterbi_symbols     = 71453248;
-    expected.num_corrected_viterbi_symbols = 1147334;
-    expected.num_bad_messages              = 39;
-    expected.meas_frequency_valid_flag     = 1;
-    expected.measured_frequency            = 1555808020.7808383;
+    expected.total_bad_unique_word_bits     = 9939;
+    expected.total_num_viterbi_symbols      = 71453248;
+    expected.num_corrected_viterbi_symbols  = 1147334;
+    expected.num_bad_messages               = 39;
+    expected.meas_frequency_valid_flag      = 1;
+    expected.measured_frequency             = 1555808020.7808383;
 
     const auto message = serialize(expected);
     return makeGenoutRecord(message.data(), message.size());

--- a/trimble_driver/test/test_gsof_pcap.cpp
+++ b/trimble_driver/test/test_gsof_pcap.cpp
@@ -1,0 +1,851 @@
+/*
+ * Copyright (c) 2024. Trimble Inc.
+ * All rights reserved.
+ */
+
+/**
+ * Regression tests that parse captures taken from real receivers. They are built but deliberately not registered
+ * with ctest, see trmb_cc_test(NO_DISCOVER). Run the trimble_driver_pcap_test binary from test/data manually.
+ */
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <array>
+#include <cstring>
+#include <optional>
+#include <random>
+#include <string>
+#include <vector>
+
+#include "streaming_test.h"
+#include "trimble_driver/gsof/packet_parser.h"
+#include "trimble_driver/gsof/stream_page_parser.h"
+
+using trmb::gsof::Message;
+using trmb::gsof::PacketParser;
+using trmb::gsof::PublicPacketParser;
+
+static constexpr char k_apx18_ip_addr[]    = "238.0.0.1";
+static constexpr int k_apx18_port          = 5018;
+static constexpr char k_applus60_ip_addr[] = "238.0.0.1";
+static constexpr int k_applus60_port       = 5018;
+
+class Applus60Gsof : public ::testing::Test {
+ public:
+  std::optional<PublicPacketParser> openPcap(const std::string &filename) {
+    pcap_reader_.emplace(filename, k_applus60_ip_addr, k_applus60_port, network::ProtocolType::TCP);
+    if (!(*pcap_reader_)) return std::nullopt;
+
+    pcap_reader_->readSingle(&payload_);
+    if (payload_.data == nullptr) return std::nullopt;
+
+    return PacketParser(reinterpret_cast<const std::byte *>(payload_.data), payload_.length);
+  }
+
+ protected:
+  std::optional<network::PcapReader> pcap_reader_ = std::nullopt;
+  network::NonOwningBuffer payload_{nullptr, 0};
+};
+
+TEST_F(Applus60Gsof, positionTimeInfoGsof1) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof1.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+  ASSERT_EQ(it->getHeader().type, 0x01);
+  ASSERT_EQ(it->getHeader().length, 10);
+
+  using namespace trmb::gsof;
+  auto position_time = it->as<PositionTimeInfo>();
+  ASSERT_EQ(position_time.gps_time_ms, 143605000u);
+  ASSERT_EQ(position_time.gps_week, 2225);
+  ASSERT_EQ(position_time.number_space_vehicles_used, 25);
+  ASSERT_TRUE(position_time.isNewPos());
+  ASSERT_TRUE(position_time.isClockFix());
+  ASSERT_TRUE(position_time.isHCoordinatesComputedHere());
+  ASSERT_TRUE(position_time.isHeightComputedHere());
+  ASSERT_TRUE(position_time.isLeastSquares());
+  ASSERT_TRUE(position_time.isL1PseudoRangeUsed());
+
+  ASSERT_FALSE(position_time.isDiffSoln());
+  ASSERT_FALSE(position_time.isDiffPosInPhase());
+  ASSERT_FALSE(position_time.isDiffPosFixedInt());
+  ASSERT_FALSE(position_time.isOmnistarSoln());
+  ASSERT_FALSE(position_time.isStaticConstr());
+  ASSERT_FALSE(position_time.isNetworkRtkSoln());
+  ASSERT_FALSE(position_time.isRtkLocation());
+  ASSERT_FALSE(position_time.isBeaconDGPS());
+}
+
+TEST_F(Applus60Gsof, latLongHeightGsof2) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof2.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 0x02);
+  ASSERT_EQ(header.length, 24);
+
+  using namespace trmb::gsof;
+  const auto lla = it->as<LatLongHeight>();
+
+  // Using approximate office coordinates
+  ASSERT_NEAR(lla.lla.latitude, 0.77, 1e-2);
+  ASSERT_NEAR(lla.lla.longitude, -1.39, 1e-2);
+  ASSERT_NEAR(lla.lla.altitude, 168, 1);
+}
+
+TEST_F(Applus60Gsof, ecefPositionGsof3) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof3.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 0x03);
+  ASSERT_EQ(header.length, 24);
+
+  using namespace trmb::gsof;
+  const auto ecef = it->as<EcefPosition>();
+
+  // Looked at GUI and converted approximate coordinates of degrees-minutes-seconds to ecef
+  ASSERT_NEAR(ecef.pos.x, 848942.99, 10);
+  ASSERT_NEAR(ecef.pos.y, -4527384.15, 10);
+  ASSERT_NEAR(ecef.pos.z, 4397104.00, 10);
+}
+
+TEST_F(Applus60Gsof, ecefDeltaGsof6) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof6.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 0x06);
+  ASSERT_EQ(header.length, 24);
+
+  using namespace trmb::gsof;
+  const auto ecef_delta = it->as<EcefDelta>();
+
+  // Converted from bytes shown in wireshark
+  // RTCMv3 input was from apply-bb-01.ddns.net:2101/Downtown_Base_RTCM_32_MSM4
+  ASSERT_NEAR(ecef_delta.delta.x, -3473.5847978937672, 1e-4);
+  ASSERT_NEAR(ecef_delta.delta.y, 10602.019044206478, 1e-4);
+  ASSERT_NEAR(ecef_delta.delta.z, 11631.403884239495, 1e-4);
+}
+
+TEST_F(Applus60Gsof, tplaneDeltaGsof7) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof7.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 0x07);
+  ASSERT_EQ(header.length, 24);
+
+  using namespace trmb::gsof;
+  const auto tplane_delta = it->as<TangentPlaneDelta>();
+
+  // Converted from bytes shown in wireshark
+  // RTCMv3 input was from appl-bb-01.ddns.net:2101/Downtown_Base_RTCM_32_MSM4
+  ASSERT_NEAR(tplane_delta.enu.east, -1456.685759244824, 1e-4);
+  ASSERT_NEAR(tplane_delta.enu.north, 16051.050661617326, 1e-4);
+  ASSERT_NEAR(tplane_delta.enu.up, 43.853000930700546, 1e-4);
+}
+
+TEST_F(Applus60Gsof, velocityGsof8) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof8.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 0x08);
+  ASSERT_EQ(header.length, 13);
+
+  using namespace trmb::gsof;
+  const auto velocity = it->as<Velocity>();
+
+  // Converted from bytes shown in wireshark
+  ASSERT_FLOAT_EQ(velocity.velocity, 0.00597169);
+  ASSERT_FLOAT_EQ(velocity.heading, 2.062232);
+  ASSERT_FLOAT_EQ(velocity.vertical_velocity, -0.0006348496);
+  ASSERT_FALSE(velocity.local_heading);  // No local heading
+
+  ASSERT_TRUE(velocity.isVelDataValid());
+  ASSERT_EQ(velocity.getVelocitySource(), Velocity::VelocitySource::k_consecutive_measurements);
+  ASSERT_TRUE(velocity.isHeadingDataValid());
+}
+
+TEST_F(Applus60Gsof, pdopInfoGsof9) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof9.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 0x09);
+  ASSERT_EQ(header.length, 16);
+
+  using namespace trmb::gsof;
+  const auto dop = it->as<PdopInfo>();
+
+  // Converted from bytes shown in wireshark
+  ASSERT_FLOAT_EQ(dop.position_dop, 0.9000375);
+  ASSERT_FLOAT_EQ(dop.horiziontal_dop, 0.488651454);
+  ASSERT_FLOAT_EQ(dop.vertical_dop, 0.7558355);
+  ASSERT_FLOAT_EQ(dop.time_dop, 1.13949406);
+}
+
+TEST_F(Applus60Gsof, clockInfoGsof10) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof10.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 10);
+  ASSERT_EQ(header.length, 17);
+
+  using namespace trmb::gsof;
+  const auto clock = it->as<ClockInfo>();
+
+  ASSERT_TRUE(clock.isClockOffsetValid());
+  ASSERT_TRUE(clock.isFreqOffsetValid());
+  ASSERT_TRUE(clock.isReceiverInAnywhereFixMode());
+
+  ASSERT_NEAR(clock.clock_offset, 0.007924753666675877, 1e-5);
+  ASSERT_NEAR(clock.freq_offset, -1.6607935199691757, 1e-5);
+}
+
+TEST_F(Applus60Gsof, positionVcvGsof11) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof11.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 11);
+  ASSERT_EQ(header.length, 34);
+
+  using namespace trmb::gsof;
+  const auto covariance = it->as<PositionVcvInfo>();
+
+  ASSERT_FLOAT_EQ(covariance.position_rms, 0.001);
+  ASSERT_FLOAT_EQ(covariance.xx, 0.0004194359);
+  ASSERT_FLOAT_EQ(covariance.xy, 0.0000253239959);
+  ASSERT_FLOAT_EQ(covariance.xz, 0.0000135725622);
+  ASSERT_FLOAT_EQ(covariance.yy, 0.000340281957);
+  ASSERT_FLOAT_EQ(covariance.yz, 0.0000268921121);
+  ASSERT_FLOAT_EQ(covariance.zz, 0.0003106595);
+  ASSERT_FLOAT_EQ(covariance.unit_var, 1.0f);
+  ASSERT_EQ(covariance.num_epochs, 0);
+}
+
+TEST_F(Applus60Gsof, positionSigmaGsof12) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof12.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 12);
+  ASSERT_EQ(header.length, 38);
+
+  using namespace trmb::gsof;
+  const auto sigma = it->as<PositionSigmaInfo>();
+
+  ASSERT_FLOAT_EQ(sigma.position_rms, 0.001);
+  ASSERT_FLOAT_EQ(sigma.sigma_east, 0.200461134);
+  ASSERT_FLOAT_EQ(sigma.sigma_north, 0.0194671229);
+  ASSERT_FLOAT_EQ(sigma.covariance_east_north, -0.000291388424);
+  ASSERT_FLOAT_EQ(sigma.sigma_up, 0.0169321168);
+  ASSERT_FLOAT_EQ(sigma.semi_major_axis, 0.200466454);
+  ASSERT_FLOAT_EQ(sigma.semi_minor_axis, 0.0194122624);
+  ASSERT_FLOAT_EQ(sigma.orientation, 90.41939);
+  ASSERT_FLOAT_EQ(sigma.unit_variance, 1);
+  ASSERT_EQ(sigma.number_epochs, 0);
+}
+
+TEST_F(Applus60Gsof, receiverSerialNumberGsof15) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof15.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 15);
+  ASSERT_EQ(header.length, 4);
+
+  using namespace trmb::gsof;
+  const auto serial = it->as<ReceiverSerialNumber>();
+
+  ASSERT_EQ(serial.number, 573901879);
+}
+
+TEST_F(Applus60Gsof, currentTimeGsof16) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof16.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 16);
+  ASSERT_EQ(header.length, 9);
+
+  using namespace trmb::gsof;
+  const auto time = it->as<CurrentTime>();
+
+  ASSERT_EQ(time.gps_ms_week, 162117007u);
+  ASSERT_EQ(time.gps_week, 2225u);
+  ASSERT_EQ(time.utc_offset, 18u);
+
+  ASSERT_TRUE(time.isTimeInfoValid());
+  ASSERT_TRUE(time.isUtcOffsetValid());
+}
+
+TEST_F(Applus60Gsof, attitudeInfoGsof27) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof27.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 27);
+  ASSERT_EQ(header.length, 70);
+
+  using namespace trmb::gsof;
+  const auto attitude = it->as<AttitudeInfo>();
+
+  ASSERT_EQ(attitude.gps_time, 162629000u);
+  ASSERT_TRUE(attitude.isCalibrated());
+  ASSERT_TRUE(attitude.isPitchValid());
+  ASSERT_TRUE(attitude.isYawValid());
+  ASSERT_TRUE(attitude.isRollValid());
+  ASSERT_FALSE(attitude.isScalarValid());
+  ASSERT_FALSE(attitude.isDiagValid());
+  ASSERT_FALSE(attitude.isSlaveStatic());
+  ASSERT_FALSE(attitude.isErrValid());
+  ASSERT_EQ(attitude.num_svs, 27);
+  ASSERT_EQ(attitude.calc_mode.getCalcMode(), Mode::CalcMode::RTK_FIX);
+  ASSERT_DOUBLE_EQ(attitude.pyr.pitch, -6.92433215936082754188296561892E-3);
+  ASSERT_DOUBLE_EQ(attitude.pyr.yaw, 3.131870495343419);
+  ASSERT_DOUBLE_EQ(attitude.pyr.roll, 3.135750624153477);
+  ASSERT_DOUBLE_EQ(attitude.master_slave_range, 0.0);
+  ASSERT_EQ(attitude.pdop, 10);
+  ASSERT_TRUE(attitude.variance.has_value());
+  ASSERT_FLOAT_EQ(attitude.variance->pitch, 0.000003936937);
+  ASSERT_FLOAT_EQ(attitude.variance->yaw, 0.0000271099088);
+  ASSERT_FLOAT_EQ(attitude.variance->roll, 0.00000382736971);
+  ASSERT_FLOAT_EQ(attitude.variance->pitch_yaw, 0.0);
+  ASSERT_FLOAT_EQ(attitude.variance->pitch_roll, 0.0);
+  ASSERT_FLOAT_EQ(attitude.variance->yaw_roll, 0.0);
+  ASSERT_FLOAT_EQ(attitude.variance->master_slave_range, 0.0);
+}
+
+TEST_F(Applus60Gsof, allSvBriefInfoGsof33) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof33.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 33);
+  ASSERT_EQ(header.length, 101);
+
+  using namespace trmb::gsof;
+  const auto brief_sv_info = it->as<AllSvBrief>();
+  ASSERT_EQ(brief_sv_info.num_svs, 25);
+  ASSERT_EQ(brief_sv_info.sv_info.size(), 25ul);
+  const std::array<uint8_t, 25> expected_prn                  = {0x0b, 0x19, 0x0c, 0x17, 0x05, 0x1d, 0x0d, 0x02, 0x08,
+                                                                 0x07, 0x06, 0x14, 0x14, 0x0f, 0x03, 0x29, 0x0d, 0x20,
+                                                                 0x0f, 0x15, 0x1b, 0x07, 0x08, 0x1a, 0x1e};
+  const std::array<SatelliteType, 25> expected_satellite_type = {
+      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GLONASS,
+      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GPS,
+      SatelliteType::GLONASS, SatelliteType::GLONASS, SatelliteType::GPS,     SatelliteType::BEIDOU,
+      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GALILEO, SatelliteType::BEIDOU,
+      SatelliteType::GALILEO, SatelliteType::BEIDOU,  SatelliteType::GALILEO, SatelliteType::GALILEO,
+      SatelliteType::BEIDOU,  SatelliteType::GALILEO, SatelliteType::GALILEO, SatelliteType::GALILEO,
+      SatelliteType::BEIDOU};
+
+  for (std::size_t i = 0; i < 25; ++i) {
+    const auto &info = brief_sv_info.sv_info[i];
+    ASSERT_EQ(info.prn, expected_prn[i]);
+    ASSERT_EQ(info.getSVSystemMode(), expected_satellite_type[i]);
+    ASSERT_TRUE(info.isAboveHor());
+    ASSERT_TRUE(info.isAssignedToChannel());
+    ASSERT_TRUE(info.isTracked());
+  }
+}
+
+TEST_F(Applus60Gsof, allSvDetailedInfoGsof34) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof34.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 34);
+  ASSERT_EQ(header.length, 0xf1);
+
+  using namespace trmb::gsof;
+  const auto sv_info = it->as<AllSvDetailed>();
+  ASSERT_EQ(sv_info.num_svs, 24);
+  ASSERT_EQ(sv_info.sv_info.size(), 24ul);
+  const std::array<uint8_t, 24> expected_prn = {0x17, 0x12, 0x17, 0x05, 0x1d, 0x0d, 0x18, 0x02, 0x08, 0x01, 0x14, 0x1e,
+                                                0x14, 0x0f, 0x0d, 0x20, 0x1d, 0x21, 0x07, 0x08, 0x1a, 0x1e, 0x17, 0x14};
+  const std::array<SatelliteType, 24> expected_satellite_type = {
+      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GLONASS,  SatelliteType::GPS,
+      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GLONASS,  SatelliteType::GPS,
+      SatelliteType::GLONASS, SatelliteType::GLONASS, SatelliteType::BEIDOU,   SatelliteType::GPS,
+      SatelliteType::GPS,     SatelliteType::GPS,     SatelliteType::GALILEO,  SatelliteType::BEIDOU,
+      SatelliteType::BEIDOU,  SatelliteType::GALILEO, SatelliteType::GALILEO,  SatelliteType::GALILEO,
+      SatelliteType::GALILEO, SatelliteType::BEIDOU,  SatelliteType::OMNISTAR, SatelliteType::BEIDOU};
+
+  const std::array<bool, 24> expected_dual_freq_tracking = {true,  true, false, false, true,  true,  false, true,
+                                                            true,  true, false, true,  false, true,  true,  false,
+                                                            false, true, true,  true,  true,  false, false, false};
+
+  const std::array<bool, 24> expected_l1g1_freq_reports = {true, true, true, true, true, true, true,  true,
+                                                           true, true, true, true, true, true, true,  true,
+                                                           true, true, true, true, true, true, false, true};
+
+  const std::array<bool, 24> expected_l1g2_freq_reports = {true, true, false, true, true, true, true,  true,
+                                                           true, true, true,  true, true, true, true,  true,
+                                                           true, true, true,  true, true, true, false, true};
+
+  const std::array<bool, 24> expected_used_at_current_pos = {false, true, true, true, true, true, false, true,
+                                                             false, true, true, true, true, true, true,  true,
+                                                             true,  true, true, true, true, true, false, true};
+
+  const std::array<bool, 24> expected_used_in_rtk_solution = {false, false, false, false, true,  false, false, false,
+                                                              false, false, false, false, false, false, false, false,
+                                                              true,  false, true,  false, false, false, false, false};
+
+  const std::array<bool, 24> expected_pcode_l1g1 = {false, false, false, false, false, false, false, false,
+                                                    false, false, true,  false, false, false, true,  true,
+                                                    true,  true,  true,  true,  true,  true,  false, false};
+
+  const std::array<bool, 24> expected_cs_l2_tracking = {true,  true,  false, false, true,  false, false, false,
+                                                        false, false, false, true,  false, true,  false, false,
+                                                        false, false, false, false, false, false, false, false};
+
+  const std::array<bool, 24> expected_l5_tracking = {true,  true,  false, false, false, false, false, false,
+                                                     false, false, false, true,  false, false, false, false,
+                                                     false, false, false, false, false, false, false, false};
+
+  const std::array<bool, 24> expected_glonass_mtype = {false, false, true,  false, false, false, true,  false,
+                                                       true,  true,  false, false, false, false, false, false,
+                                                       false, false, false, false, false, false, false, false};
+
+  for (std::size_t i = 0; i < 24; ++i) {
+    const auto &info = sv_info.sv_info[i];
+    ASSERT_EQ(info.prn, expected_prn[i]);
+    ASSERT_EQ(info.getSvType(), expected_satellite_type[i]);
+
+    if (info.getSvType() != SatelliteType::OMNISTAR) {
+      ASSERT_TRUE(info.isAboveHor());
+      ASSERT_TRUE(info.isAssignedToChannel());
+      ASSERT_TRUE(info.isTracked());
+    } else {
+      ASSERT_FALSE(info.isAboveHor());
+      ASSERT_FALSE(info.isAssignedToChannel());
+      ASSERT_FALSE(info.isTracked());
+    }
+
+    ASSERT_EQ(info.isCurrTrackedDual(), expected_dual_freq_tracking[i]);
+    ASSERT_EQ(info.isL1G1Freq(), expected_l1g1_freq_reports[i]);
+    ASSERT_EQ(info.isL1G2Freq(), expected_l1g2_freq_reports[i]);
+    ASSERT_EQ(info.isUsedAtCurrentPos(), expected_used_at_current_pos[i]);
+    ASSERT_EQ(info.isUsedInRtkSolution(), expected_used_in_rtk_solution[i]);
+
+    ASSERT_EQ(info.isTrackPCodeL1G1(), expected_pcode_l1g1[i]);
+    ASSERT_FALSE(info.isTrackPCodeL2());
+    ASSERT_EQ(info.isTrackingCsOnL2(), expected_cs_l2_tracking[i]) << "with i " << i << " and " << int(info.sv_system);
+    ASSERT_EQ(info.isTrackingL5Signal(), expected_l5_tracking[i]);
+
+    ASSERT_EQ(info.isGlonassMSv(), expected_glonass_mtype[i]);
+    ASSERT_FALSE(info.isGlonassKSv());
+  }
+}
+
+TEST_F(Applus60Gsof, receivedBaseInfoGsof35) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof35.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 35);
+  ASSERT_EQ(header.length, 35);
+
+  using namespace trmb::gsof;
+  const auto base_info = it->as<ReceivedBaseInfo>();
+
+  const std::array<char, 8> expected_name = {'R', 'T', 'C', 'M', '0', '0', '0', '0'};
+  ASSERT_EQ(expected_name, base_info.name);
+  ASSERT_EQ(base_info.getVersionNumber(), 0);
+  ASSERT_EQ(base_info.id, 0);
+  ASSERT_TRUE(base_info.isBaseInfoValid());
+
+  ASSERT_DOUBLE_EQ(base_info.base_lla.latitude, 0.7630018859478892);
+  ASSERT_DOUBLE_EQ(base_info.base_lla.longitude, -1.385119519554126);
+  ASSERT_DOUBLE_EQ(base_info.base_lla.altitude, 101.22497844472646);
+}
+
+TEST_F(Applus60Gsof, batteryMemoryInfoGsof37) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof37.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 37);
+  ASSERT_EQ(header.length, 10);
+
+  using namespace trmb::gsof;
+  const auto battery = it->as<BatteryMemoryInfo>();
+
+  ASSERT_EQ(battery.battery_cap, 100);
+  ASSERT_DOUBLE_EQ(battery.remaining_time, 1343.1210074074074);
+}
+
+TEST_F(Applus60Gsof, positionTypeGsof38) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof38.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 38);
+  ASSERT_EQ(header.length, 26);
+
+  using namespace trmb::gsof;
+  const auto type = it->as<PositionTypeInformation>();
+  ASSERT_EQ(type.unparsed_bytes.size(), 0ul);
+
+  ASSERT_FLOAT_EQ(type.error_scale, 1.f);
+  ASSERT_FALSE(type.isSolutionWideArea());
+  ASSERT_TRUE(type.isRtkFixSolution());
+  ASSERT_EQ(type.getSolutionIntegrity(), SolutionIntegrity::k_initialization_passed);
+  ASSERT_EQ(type.getRtkCondition(), RtkCondition::k_new_position_computed);
+  ASSERT_FALSE(type.isNewPhysicalBaseStationAvailable());
+  ASSERT_FLOAT_EQ(type.correction_age, 0.0f);
+  ASSERT_EQ(type.getRtcmStatus(), RtcmStatus::k_not_available_or_unknown);
+  ASSERT_FALSE(type.isGeofenceEnabledAndTriggered());
+  ASSERT_FALSE(type.isRtkRangeLimitExceeded());
+  ASSERT_FALSE(type.isXFillPosition());
+  ASSERT_FALSE(type.isRtkPosition());
+  ASSERT_FALSE(type.isRtxOrXFillLinkDown());
+
+  ASSERT_FALSE(type.isXFillReady());
+  ASSERT_FALSE(type.isRtxSolutionRain());
+  ASSERT_FALSE(type.isXFillRtxOffsetGood());
+  ASSERT_FALSE(type.isCmrxeReceived());
+  ASSERT_FALSE(type.isRtxInWetArea());
+
+  ASSERT_EQ(type.frame_flag, 0);
+  ASSERT_EQ(type.itrf_epoch, 0);
+  ASSERT_EQ(type.tectonic_plate, 0);
+  ASSERT_EQ(type.rtx_ram_sub_minutes_left, 0);
+  ASSERT_EQ(type.pole_wobble_status_flag, 0);
+  ASSERT_FLOAT_EQ(type.pole_wobble_distance, 0.0f);
+  ASSERT_EQ(type.getPositionFixType(), PositionFix::k_ins_rtk);
+}
+
+TEST_F(Applus60Gsof, lbandStatusGsof40) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof40.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 40);
+  ASSERT_EQ(header.length, 70);
+
+  using namespace trmb::gsof;
+  const auto lband_status = it->as<LbandStatusInfo>();
+
+  const std::array<char, 5> expected_name = {'R', 'T', 'X', 'N', 'A'};
+  ASSERT_EQ(lband_status.satellite_name, expected_name);
+
+  // This frequency and baud rate were taken from https://positioningservices.trimble.com/resources/sat/ it is the
+  // North America RTX beam frequency and baud
+  ASSERT_FLOAT_EQ(lband_status.nominal_sat_freq, 1555.8080f);
+  ASSERT_EQ(lband_status.sat_bit_rate, 2400);
+
+  ASSERT_NEAR(static_cast<double>(lband_status.c_no), 47.0, 0.1);  // GUI just says 47
+  ASSERT_EQ(lband_status.getHpXpEngine(), omnistar::HpXpEngine::k_hp);
+  ASSERT_EQ(lband_status.getHpXpLibraryMode(), omnistar::HpXpLibraryMode::k_not_active);
+  ASSERT_EQ(lband_status.getVbsLibraryMode(), omnistar::VbsLibraryMode::k_not_active);
+  ASSERT_EQ(lband_status.getBeamMode(), omnistar::BeamMode::k_tracking);
+  ASSERT_EQ(lband_status.getMotionState(), omnistar::MotionState::k_unknown);
+  ASSERT_FLOAT_EQ(lband_status.sigma_hor_threshold, 0.3f);
+  ASSERT_FLOAT_EQ(lband_status.sigma_ver_threshold, 0.3f);
+  ASSERT_EQ(lband_status.getNmeaEncryptionState(), omnistar::NmeaEncryptionState::k_off);
+
+  ASSERT_FLOAT_EQ(lband_status.i_q_ratio, 5.08325863);
+  ASSERT_FLOAT_EQ(lband_status.estimated_bit_error_rate, 0.000029838955);
+
+  ASSERT_EQ(lband_status.total_messages, 8790u);
+  ASSERT_EQ(lband_status.total_unique_words_with_errors, 3265u);
+  ASSERT_EQ(lband_status.total_bad_unique_word_bits, 9939u);
+  ASSERT_EQ(lband_status.total_num_viterbi_symbols, 71453248u);
+  ASSERT_EQ(lband_status.num_corrected_viterbi_symbols, 1147334u);
+  ASSERT_EQ(lband_status.num_bad_messages, 39u);
+
+  ASSERT_TRUE(lband_status.isMeasuredFrequencyValid());
+  ASSERT_DOUBLE_EQ(lband_status.measured_frequency, 1555808020.7808383);
+}
+
+TEST_F(Applus60Gsof, basePositionQualityGsof41) {
+  auto maybe_gsof_parser = openPcap("applus60_gsof41.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+
+  const auto &header = it->getHeader();
+  ASSERT_EQ(header.type, 41);
+  ASSERT_EQ(header.length, 31);
+
+  using namespace trmb::gsof;
+  const auto base_qual = it->as<BasePositionAndQualityIndicator>();
+
+  ASSERT_EQ(base_qual.gps_time_ms, 328103007u);
+  ASSERT_EQ(base_qual.gps_week_number, 2225u);
+  ASSERT_DOUBLE_EQ(base_qual.llh.latitude, 0.7630018859478892);
+  ASSERT_DOUBLE_EQ(base_qual.llh.longitude, -1.385119519554126);
+  ASSERT_DOUBLE_EQ(base_qual.llh.altitude, 101.22497844472646);
+  ASSERT_EQ(base_qual.getBaseQuality(), BaseQuality::k_omnistar_xp_hp_or_rtk_float);
+}
+
+TEST(GsofPcapParsingTest, fullNavigationInfoGsof49) {
+  network::NonOwningBuffer payload{nullptr, 0};
+  network::PcapReader pcap_reader("apx_18_fullnavinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
+                                  network::ProtocolType::TCP);
+  ASSERT_TRUE(static_cast<bool>(pcap_reader));
+  ASSERT_TRUE(pcap_reader.readSingle(&payload));
+  ASSERT_NE(payload.data, nullptr);
+
+  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+  ASSERT_EQ(it->getHeader().type, 0x31);
+  ASSERT_EQ(it->getHeader().length, 0x68);  // Read our ICD not the GSOF stuff on the web
+
+  using namespace trmb::gsof;
+  auto solution = it->as<NavigationSolution>();
+  ASSERT_EQ(solution.gps_time.week, 2080);  // week of nov 17th 2019
+  // Guesstimated Google Maps lat long of Trimble Applanix Richmond Hill - Canada office
+  ASSERT_NEAR(solution.lla.latitude, 43.86, 1e-2);
+  ASSERT_NEAR(solution.lla.longitude, -79.38, 1e-2);
+
+  ASSERT_NE(solution.status.getImuAlignmentStatus(), Status::ImuAlignmentStatus::UNKNOWN);
+  ASSERT_NE(solution.status.getGnssStatus(), Status::GnssStatus::UNKNOWN);
+}
+
+TEST(GsofPcapParsingTest, fullNavigationRmsGsof50) {
+  network::NonOwningBuffer payload{nullptr, 0};
+  network::PcapReader pcap_reader("apx_18_fullrmsinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
+                                  network::ProtocolType::TCP);
+  ASSERT_TRUE(static_cast<bool>(pcap_reader));
+  ASSERT_TRUE(pcap_reader.readSingle(&payload));
+  ASSERT_NE(payload.data, nullptr);
+
+  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+
+  auto it = message_parser.begin();
+  using namespace trmb::gsof;
+  auto rms = it->as<NavigationPerformance>();
+  ASSERT_EQ(rms.gps_time.week, 2080);
+
+  ASSERT_NE(rms.status.getImuAlignmentStatus(), Status::ImuAlignmentStatus::UNKNOWN);
+  ASSERT_NE(rms.status.getGnssStatus(), Status::GnssStatus::UNKNOWN);
+
+  ++it;
+  ASSERT_EQ(it, message_parser.end());
+}
+
+TEST(GsofPcapParsingTest, dmiRawDataGsof52) {
+  network::NonOwningBuffer payload{nullptr, 0};
+  network::PcapReader pcap_reader("apx_18_gsof52_dmirawdata_single.pcap", k_apx18_ip_addr, k_apx18_port,
+                                  network::ProtocolType::TCP);
+  ASSERT_TRUE(static_cast<bool>(pcap_reader));
+  ASSERT_TRUE(pcap_reader.readSingle(&payload));
+  ASSERT_NE(payload.data, nullptr);
+
+  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+
+  auto it = message_parser.begin();
+  using namespace trmb::gsof;
+  auto dmiRawData = it->as<DmiRawData>();
+  ASSERT_EQ(dmiRawData.gps_time.week, 2122);
+  ASSERT_EQ(dmiRawData.num_raw_meas, 10);
+  ASSERT_EQ(dmiRawData.time_offset, 0);
+  ASSERT_EQ(dmiRawData.abs_dist_count, 0ul);
+  ASSERT_EQ(dmiRawData.ud_dist_count, 0);
+
+  ++it;
+  ASSERT_EQ(it, message_parser.end());
+}
+
+TEST(GsofPcapParsingTest, iterator) {
+  network::NonOwningBuffer payload{nullptr, 0};
+  network::PcapReader pcap_reader("apx_18_fullnavinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
+                                  network::ProtocolType::TCP);
+  ASSERT_TRUE(static_cast<bool>(pcap_reader));
+  ASSERT_TRUE(pcap_reader.readSingle(&payload));
+  ASSERT_NE(payload.data, nullptr);
+
+  PacketParser gsof_parser(reinterpret_cast<const std::byte *>(payload.data), payload.length);
+
+  using namespace trmb;
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_49_INS_FULL_NAV);
+  ++it;
+  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_50_INS_RMS);
+  ++it;
+  ASSERT_EQ(it, message_parser.end());
+}
+
+TEST(GsofPcapParsingTest, streamParser) {
+  network::NonOwningBuffer payload{nullptr, 0};
+  network::PcapReader pcap_reader("apx_18_fullnavinfo_single.pcap", k_apx18_ip_addr, k_apx18_port,
+                                  network::ProtocolType::TCP);
+  ASSERT_TRUE(static_cast<bool>(pcap_reader));
+  ASSERT_TRUE(pcap_reader.readSingle(&payload));
+  ASSERT_NE(payload.data, nullptr);
+
+  std::random_device rd;
+  std::mt19937 gen(rd());
+  std::uniform_int_distribution<> distribution(1, 512);
+
+  std::array<std::uint8_t, 512> buf{};
+  trmb::gsof::StreamPageParser stream_parser;
+  std::optional<std::vector<std::byte>> result = std::nullopt;
+
+  stream_parser.registerGsofPageFoundCallback([&payload, &result](const std::vector<std::byte> &page) {
+    ASSERT_EQ(page.size(), payload.length);
+    result = page;
+  });
+
+  // Pass on random sized buffers to the stream parser
+  for (std::size_t bytes_read = 0; bytes_read < payload.length;) {
+    int bytes_to_read = std::min(distribution(gen), static_cast<int>(payload.length - bytes_read));
+    std::memcpy(buf.data(), payload.data + bytes_read, bytes_to_read);
+    bytes_read += bytes_to_read;
+
+    stream_parser.readSome(buf.data(), bytes_to_read);
+  }
+
+  // Now prove that you can parse the resulting vector of bytes using the packet parser
+  ASSERT_TRUE(result.has_value());  // For -Wmaybe-uninitialized
+
+  PacketParser gsof_parser(result->data(), result->size());
+  ASSERT_TRUE(gsof_parser.isValid());
+  ASSERT_TRUE(gsof_parser.isSupported());
+
+  using namespace trmb;
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_49_INS_FULL_NAV);
+  ++it;
+  ASSERT_EQ(it->getHeader().type, gsof::GSOF_ID_50_INS_RMS);
+  ++it;
+  ASSERT_EQ(it, message_parser.end());
+}

--- a/trimble_driver/test/test_gsof_streaming.cpp
+++ b/trimble_driver/test/test_gsof_streaming.cpp
@@ -5,37 +5,84 @@
 
 #include <gtest/gtest.h>
 
-#include <chrono>
+#include <algorithm>
 #include <set>
+#include <vector>
 
-#include "streaming_test.h"
+#include "gsof_record_builder.h"
 #include "trimble_driver/gsof/packet_parser.h"
 #include "trimble_driver/gsof/stream_chapter_parser.h"
 #include "trimble_driver/gsof/stream_page_parser.h"
 
+using gsof_test::makeGenoutRecord;
+using gsof_test::makeGenoutTransmission;
+using gsof_test::serialize;
 using trmb::gsof::Message;
 using trmb::gsof::PacketParser;
 using trmb::gsof::PublicPacketParser;
 
-static constexpr char k_apx18_ip_addr[] = "238.0.0.1";
-static constexpr int k_apx18_port       = 5018;
+namespace {
 
-class Apx18StreamingGsofTest : public StreamingTest {
- public:
-  Apx18StreamingGsofTest()
-      : StreamingTest("apx_18_fullnav_fullrmsinfo.pcap", k_apx18_ip_addr, k_apx18_port, network::ProtocolType::TCP) {}
-};
+/**
+ * @brief Builds a GENOUT record holding a full INS nav solution and its associated RMS error values.
+ */
+std::vector<std::byte> makeNavAndRmsRecord(uint32_t gps_time_msec) {
+  using namespace trmb::gsof;
 
-TEST_F(Apx18StreamingGsofTest, streamParserWithOverlap) {
+  NavigationSolution solution{};
+  solution.header.type        = GSOF_ID_49_INS_FULL_NAV;
+  solution.header.length      = sizeof(NavigationSolution) - sizeof(Header);
+  solution.gps_time.week      = 2226;
+  solution.gps_time.time_msec = gps_time_msec;
+
+  NavigationPerformance rms{};
+  rms.header.type        = GSOF_ID_50_INS_RMS;
+  rms.header.length      = sizeof(NavigationPerformance) - sizeof(Header);
+  rms.gps_time.week      = 2226;
+  rms.gps_time.time_msec = gps_time_msec;
+
+  auto messages           = serialize(solution);
+  const auto rms_messages = serialize(rms);
+  messages.insert(messages.end(), rms_messages.begin(), rms_messages.end());
+
+  return makeGenoutRecord(messages.data(), messages.size());
+}
+
+/**
+ * @brief Feeds a byte stream to a parser in chunks that do not line up with the record boundaries.
+ */
+template <class ParserType>
+void readInChunks(ParserType &parser, const std::vector<std::byte> &stream, std::size_t chunk_size) {
+  const auto *data = reinterpret_cast<const std::uint8_t *>(stream.data());
+  for (std::size_t offset = 0; offset < stream.size(); offset += chunk_size) {
+    parser.readSome(data + offset, std::min(chunk_size, stream.size() - offset));
+  }
+}
+
+}  // namespace
+
+TEST(GsofStreamingTest, streamParserWithOverlap) {
+  constexpr std::size_t k_expected_pages = 5;
+  constexpr std::size_t k_chunk_size     = 37;  // Deliberately unaligned with the record size
+
+  const auto stream = [] {
+    std::vector<std::byte> bytes;
+    for (std::size_t i = 0; i < k_expected_pages; ++i) {
+      const auto record = makeNavAndRmsRecord(static_cast<uint32_t>(1000 * (i + 1)));
+      bytes.insert(bytes.end(), record.begin(), record.end());
+    }
+    return bytes;
+  }();
+
   trmb::gsof::StreamPageParser stream_parser;
-  std::optional<network::NonOwningBuffer> maybe_data = std::nullopt;
+  std::size_t page_count = 0;
 
-  stream_parser.registerGsofPageFoundCallback([](const std::vector<std::byte> &page) {
+  stream_parser.registerGsofPageFoundCallback([&page_count](const std::vector<std::byte> &page) {
     PacketParser packet_parser(page.data(), page.size());
     ASSERT_TRUE(packet_parser.isValid());
     ASSERT_TRUE(packet_parser.isSupported());
 
-    // Every record in this pcap contains a full ins nav and the associated RMS error values
+    // Every record in this stream contains a full ins nav and the associated RMS error values
     auto msg_parser = packet_parser.getMessageParser();
     ASSERT_TRUE(msg_parser.isSupported());
     ASSERT_TRUE(msg_parser.isValid());
@@ -46,33 +93,26 @@ TEST_F(Apx18StreamingGsofTest, streamParserWithOverlap) {
     ASSERT_EQ(it->getHeader().type, trmb::gsof::GSOF_ID_50_INS_RMS);
     ++it;
     ASSERT_EQ(it, msg_parser.end());
+
+    ++page_count;
   });
 
-  for (maybe_data = getData(); maybe_data.has_value(); maybe_data = getData()) {
-    stream_parser.readSome(maybe_data->data, maybe_data->length);
-  }
+  readInChunks(stream_parser, stream, k_chunk_size);
+
+  ASSERT_EQ(page_count, k_expected_pages);
 }
 
-static constexpr char applus20_ip_addr[] = "238.0.0.1";
-static constexpr int applus20_port       = 5018;
-
 /**
- * The AP+ 20 large tx pcap contains 3 DCOL-GENOUT transmissions each split over two packets. The packets should
- * contain GSOF messages 1, 2, 3, 6, 8, 9, 10, 11, 12 and 14.
+ * The transmissions below hold more messages than a single page can carry, so each one gets split over two pages.
+ * The messages are GSOF 1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 15 and 16.
  */
-class ApPlus20StreamingGsofTest : public StreamingTest {
- public:
-  ApPlus20StreamingGsofTest()
-      : StreamingTest("applus20_large_tx.pcap", applus20_ip_addr, applus20_port, network::ProtocolType::TCP) {}
-};
+TEST(GsofStreamingTest, parseMultiPacketTransmission) {
+  using namespace trmb::gsof;
 
-TEST_F(ApPlus20StreamingGsofTest, parseMultiPacketTransmission) {
-  trmb::gsof::StreamChapterParser parser;
-  std::optional<network::NonOwningBuffer> maybe_data = std::nullopt;
+  constexpr std::size_t k_expected_transmissions = 3;
+  constexpr std::size_t k_chunk_size             = 53;  // Deliberately unaligned with the page size
 
   const std::set<std::uint8_t> expected_gsof_message_ids = {1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 15, 16};
-
-  using namespace trmb::gsof;
 
   // The local heading field is not present because a planar local coordinate was not loaded, therefore the Velocity
   // message size is 15 not 19.
@@ -82,8 +122,123 @@ TEST_F(ApPlus20StreamingGsofTest, parseMultiPacketTransmission) {
       sizeof(TangentPlaneDelta) + k_expected_gsof_velocity_message_size + sizeof(PdopInfo) + sizeof(ClockInfo) +
       sizeof(PositionVcvInfo) + sizeof(PositionSigmaInfo) + sizeof(ReceiverSerialNumber) + sizeof(CurrentTime);
 
+  const auto gsof_messages = [k_expected_gsof_velocity_message_size] {
+    std::vector<std::vector<std::byte>> messages;
+
+    PositionTimeInfo position_time{};
+    position_time.header.type                = GSOF_ID_1_POS_TIME;
+    position_time.header.length              = sizeof(PositionTimeInfo) - sizeof(Header);
+    position_time.gps_time_ms                = 328103007;
+    position_time.gps_week                   = 2226;
+    position_time.number_space_vehicles_used = 25;
+    messages.push_back(serialize(position_time));
+
+    LatLongHeight llh{};
+    llh.header.type   = GSOF_ID_2_LLH;
+    llh.header.length = sizeof(LatLongHeight) - sizeof(Header);
+    llh.lla.latitude  = 0.7654321;
+    llh.lla.longitude = -1.3876543;
+    llh.lla.altitude  = 165.0;
+    messages.push_back(serialize(llh));
+
+    EcefPosition ecef{};
+    ecef.header.type   = GSOF_ID_3_ECEF;
+    ecef.header.length = sizeof(EcefPosition) - sizeof(Header);
+    ecef.pos.x         = 848942.99;
+    ecef.pos.y         = -4527384.15;
+    ecef.pos.z         = 4397104.00;
+    messages.push_back(serialize(ecef));
+
+    EcefDelta ecef_delta{};
+    ecef_delta.header.type   = GSOF_ID_6_ECEF_DELTA;
+    ecef_delta.header.length = sizeof(EcefDelta) - sizeof(Header);
+    ecef_delta.delta.x       = -3473.5847978937672;
+    ecef_delta.delta.y       = 10602.019044206478;
+    ecef_delta.delta.z       = 11631.403884239495;
+    messages.push_back(serialize(ecef_delta));
+
+    TangentPlaneDelta tplane_delta{};
+    tplane_delta.header.type   = GSOF_ID_7_TPLANE_ENU;
+    tplane_delta.header.length = sizeof(TangentPlaneDelta) - sizeof(Header);
+    messages.push_back(serialize(tplane_delta));
+
+    // Velocity has an optional trailing field so it cannot be memcpy'd as a whole struct.
+    std::vector<std::byte> velocity;
+    const auto append = [&velocity](auto value) {
+      if constexpr (sizeof(value) > 1) {
+        byteswapInPlace(&value);
+      }
+      const auto *bytes = reinterpret_cast<const std::byte *>(&value);
+      velocity.insert(velocity.end(), bytes, bytes + sizeof(value));
+    };
+    append(static_cast<uint8_t>(GSOF_ID_8_VELOCITY));
+    append(static_cast<uint8_t>(k_expected_gsof_velocity_message_size - sizeof(Header)));
+    append(static_cast<uint8_t>(0b0000'0101));
+    append(0.0f);  // velocity
+    append(0.0f);  // heading
+    append(0.0f);  // vertical velocity
+    messages.push_back(velocity);
+
+    PdopInfo dop{};
+    dop.header.type     = GSOF_ID_9_DOP;
+    dop.header.length   = sizeof(PdopInfo) - sizeof(Header);
+    dop.position_dop    = 0.9f;
+    dop.horiziontal_dop = 0.488651454f;
+    dop.vertical_dop    = 0.7558355f;
+    dop.time_dop        = 1.13949406f;
+    messages.push_back(serialize(dop));
+
+    ClockInfo clock{};
+    clock.header.type   = GSOF_ID_10_CLOCK_INFO;
+    clock.header.length = sizeof(ClockInfo) - sizeof(Header);
+    clock.clock_flags   = 0b0000'0011;  // clock offset and frequency offset valid
+    clock.clock_offset  = 0.007924753666675877;
+    clock.freq_offset   = -1.6607935199691757;
+    messages.push_back(serialize(clock));
+
+    PositionVcvInfo vcv{};
+    vcv.header.type   = GSOF_ID_11_POS_VCV_INFO;
+    vcv.header.length = sizeof(PositionVcvInfo) - sizeof(Header);
+    vcv.num_epochs    = 0;
+    messages.push_back(serialize(vcv));
+
+    PositionSigmaInfo sigma{};
+    sigma.header.type   = GSOF_ID_12_POS_SIGMA;
+    sigma.header.length = sizeof(PositionSigmaInfo) - sizeof(Header);
+    sigma.number_epochs = 0;
+    messages.push_back(serialize(sigma));
+
+    ReceiverSerialNumber serial{};
+    serial.header.type   = GSOF_ID_15_REC_SERIAL_NUM;
+    serial.header.length = sizeof(ReceiverSerialNumber) - sizeof(Header);
+    serial.number        = 573901788;
+    messages.push_back(serialize(serial));
+
+    CurrentTime time{};
+    time.header.type   = GSOF_ID_16_CURR_TIME;
+    time.header.length = sizeof(CurrentTime) - sizeof(Header);
+    time.gps_ms_week   = 328103007;
+    time.gps_week      = 2226;
+    time.utc_offset    = 18;
+    messages.push_back(serialize(time));
+
+    return messages;
+  }();
+
+  const auto stream = [&gsof_messages] {
+    std::vector<std::byte> bytes;
+    for (std::size_t i = 0; i < k_expected_transmissions; ++i) {
+      const auto transmission = makeGenoutTransmission(gsof_messages, static_cast<uint8_t>(i));
+      bytes.insert(bytes.end(), transmission.begin(), transmission.end());
+    }
+    return bytes;
+  }();
+
+  StreamChapterParser parser;
+  std::size_t chapter_count = 0;
+
   parser.registerGsofChapterFoundCallback(
-      [k_expected_payload_size, &expected_gsof_message_ids](const std::vector<std::byte> &chapter) {
+      [k_expected_payload_size, &expected_gsof_message_ids, &chapter_count](const std::vector<std::byte> &chapter) {
         ASSERT_EQ(chapter.size(), k_expected_payload_size);
         trmb::gsof::MessageParser message_parser(chapter.data(), chapter.size());
 
@@ -139,28 +294,33 @@ TEST_F(ApPlus20StreamingGsofTest, parseMultiPacketTransmission) {
         }
         ASSERT_EQ(parsed_message_count, expected_gsof_message_ids.size())
             << "Parsed message count is different from the amount of messages in the GSOF stream.";
+
+        ++chapter_count;
       });
 
-  for (maybe_data = getData(); maybe_data.has_value(); maybe_data = getData()) {
-    parser.readSome(maybe_data->data, maybe_data->length);
-  }
+  readInChunks(parser, stream, k_chunk_size);
+
+  ASSERT_EQ(chapter_count, k_expected_transmissions);
 }
 
-class ApPlus20SmallStreamingGsofTest : public StreamingTest {
- public:
-  ApPlus20SmallStreamingGsofTest()
-      : StreamingTest("applus20_small_tx.pcap", applus20_ip_addr, applus20_port, network::ProtocolType::TCP) {}
-};
-
-TEST_F(ApPlus20SmallStreamingGsofTest, singlePageStreamTest) {
+TEST(GsofStreamingTest, singlePageStreamTest) {
   // This test checks if the multipage stream parser works properly with a data stream that doesn't get split over
   // multiple pages
-  trmb::gsof::StreamChapterParser parser;
-  std::optional<network::NonOwningBuffer> maybe_data = std::nullopt;
-
   constexpr std::size_t k_expected_chapters = 10;
-  std::size_t chapter_count                 = 0;
-  uint32_t last_time                        = 0;
+  constexpr std::size_t k_chunk_size        = 41;  // Deliberately unaligned with the record size
+
+  const auto stream = [] {
+    std::vector<std::byte> bytes;
+    for (std::size_t i = 0; i < k_expected_chapters; ++i) {
+      const auto record = makeNavAndRmsRecord(static_cast<uint32_t>(1000 * (i + 1)));
+      bytes.insert(bytes.end(), record.begin(), record.end());
+    }
+    return bytes;
+  }();
+
+  trmb::gsof::StreamChapterParser parser;
+  std::size_t chapter_count = 0;
+  uint32_t last_time        = 0;
 
   parser.registerGsofChapterFoundCallback([&chapter_count, &last_time](const std::vector<std::byte> &chapter) {
     trmb::gsof::MessageParser message_parser(chapter.data(), chapter.size());
@@ -178,9 +338,7 @@ TEST_F(ApPlus20SmallStreamingGsofTest, singlePageStreamTest) {
     ++chapter_count;
   });
 
-  for (maybe_data = getData(); maybe_data.has_value(); maybe_data = getData()) {
-    parser.readSome(maybe_data->data, maybe_data->length);
-  }
+  readInChunks(parser, stream, k_chunk_size);
 
   ASSERT_EQ(chapter_count, k_expected_chapters);
 }

--- a/trimble_driver/test/test_gsof_streaming_pcap.cpp
+++ b/trimble_driver/test/test_gsof_streaming_pcap.cpp
@@ -1,0 +1,192 @@
+/*
+ * Copyright (c) 2024. Trimble Inc.
+ * All rights reserved.
+ */
+
+/**
+ * Streaming regression tests driven by captures taken from real receivers. They are built but deliberately not
+ * registered with ctest, see trmb_cc_test(NO_DISCOVER). Run the trimble_driver_pcap_test binary from test/data.
+ */
+
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <set>
+
+#include "streaming_test.h"
+#include "trimble_driver/gsof/packet_parser.h"
+#include "trimble_driver/gsof/stream_chapter_parser.h"
+#include "trimble_driver/gsof/stream_page_parser.h"
+
+using trmb::gsof::Message;
+using trmb::gsof::PacketParser;
+using trmb::gsof::PublicPacketParser;
+
+static constexpr char k_streaming_apx18_ip_addr[] = "238.0.0.1";
+static constexpr int k_streaming_apx18_port       = 5018;
+
+class Apx18StreamingGsofTest : public StreamingTest {
+ public:
+  Apx18StreamingGsofTest()
+      : StreamingTest("apx_18_fullnav_fullrmsinfo.pcap", k_streaming_apx18_ip_addr, k_streaming_apx18_port,
+                      network::ProtocolType::TCP) {}
+};
+
+TEST_F(Apx18StreamingGsofTest, streamParserWithOverlap) {
+  trmb::gsof::StreamPageParser stream_parser;
+  std::optional<network::NonOwningBuffer> maybe_data = std::nullopt;
+
+  stream_parser.registerGsofPageFoundCallback([](const std::vector<std::byte> &page) {
+    PacketParser packet_parser(page.data(), page.size());
+    ASSERT_TRUE(packet_parser.isValid());
+    ASSERT_TRUE(packet_parser.isSupported());
+
+    // Every record in this pcap contains a full ins nav and the associated RMS error values
+    auto msg_parser = packet_parser.getMessageParser();
+    ASSERT_TRUE(msg_parser.isSupported());
+    ASSERT_TRUE(msg_parser.isValid());
+
+    auto it = msg_parser.begin();
+    ASSERT_EQ(it->getHeader().type, trmb::gsof::GSOF_ID_49_INS_FULL_NAV);
+    ++it;
+    ASSERT_EQ(it->getHeader().type, trmb::gsof::GSOF_ID_50_INS_RMS);
+    ++it;
+    ASSERT_EQ(it, msg_parser.end());
+  });
+
+  for (maybe_data = getData(); maybe_data.has_value(); maybe_data = getData()) {
+    stream_parser.readSome(maybe_data->data, maybe_data->length);
+  }
+}
+
+static constexpr char applus20_ip_addr[] = "238.0.0.1";
+static constexpr int applus20_port       = 5018;
+
+/**
+ * The AP+ 20 large tx pcap contains 3 DCOL-GENOUT transmissions each split over two packets. The packets should
+ * contain GSOF messages 1, 2, 3, 6, 8, 9, 10, 11, 12 and 14.
+ */
+class ApPlus20StreamingGsofTest : public StreamingTest {
+ public:
+  ApPlus20StreamingGsofTest()
+      : StreamingTest("applus20_large_tx.pcap", applus20_ip_addr, applus20_port, network::ProtocolType::TCP) {}
+};
+
+TEST_F(ApPlus20StreamingGsofTest, parseMultiPacketTransmission) {
+  trmb::gsof::StreamChapterParser parser;
+  std::optional<network::NonOwningBuffer> maybe_data = std::nullopt;
+
+  const std::set<std::uint8_t> expected_gsof_message_ids = {1, 2, 3, 6, 7, 8, 9, 10, 11, 12, 15, 16};
+
+  using namespace trmb::gsof;
+
+  // The local heading field is not present because a planar local coordinate was not loaded, therefore the Velocity
+  // message size is 15 not 19.
+  const std::size_t k_expected_gsof_velocity_message_size = 15;
+  const std::size_t k_expected_payload_size =
+      sizeof(PositionTimeInfo) + sizeof(LatLongHeight) + sizeof(EcefPosition) + sizeof(EcefDelta) +
+      sizeof(TangentPlaneDelta) + k_expected_gsof_velocity_message_size + sizeof(PdopInfo) + sizeof(ClockInfo) +
+      sizeof(PositionVcvInfo) + sizeof(PositionSigmaInfo) + sizeof(ReceiverSerialNumber) + sizeof(CurrentTime);
+
+  parser.registerGsofChapterFoundCallback(
+      [k_expected_payload_size, &expected_gsof_message_ids](const std::vector<std::byte> &chapter) {
+        ASSERT_EQ(chapter.size(), k_expected_payload_size);
+        trmb::gsof::MessageParser message_parser(chapter.data(), chapter.size());
+
+        int parsed_message_count = 0;
+        for (const auto &message : message_parser) {
+          const trmb::gsof::Header &header = message.getHeader();
+          ASSERT_TRUE(expected_gsof_message_ids.count(header.type) > 0)
+              << "Unexpectedly encountered message of type " << std::to_string(header.type) << ".";
+          ++parsed_message_count;
+
+          // The following are just short sanity checks as the actual full parsing tests are in a different unit test
+          if (header.type == GSOF_ID_1_POS_TIME) {
+            auto position_time = message.as<PositionTimeInfo>();
+            ASSERT_EQ(position_time.gps_week, 2226);
+          } else if (header.type == GSOF_ID_2_LLH) {
+            auto llh = message.as<LatLongHeight>();
+            ASSERT_NEAR(llh.lla.altitude, 165, 1);
+          } else if (header.type == GSOF_ID_3_ECEF) {
+            auto ecef = message.as<EcefPosition>();
+            ASSERT_GT(ecef.pos.z, 0);
+          } else if (header.type == GSOF_ID_6_ECEF_DELTA) {
+            auto ecef = message.as<EcefDelta>();
+            ASSERT_GT(ecef.delta.z, 0);
+          } else if (header.type == GSOF_ID_7_TPLANE_ENU) {
+            auto tplane_enu_delta = message.as<TangentPlaneDelta>();
+            ASSERT_DOUBLE_EQ(tplane_enu_delta.enu.east, 0.0);
+            ASSERT_DOUBLE_EQ(tplane_enu_delta.enu.north, 0.0);
+            ASSERT_DOUBLE_EQ(tplane_enu_delta.enu.up, 0.0);
+          } else if (header.type == GSOF_ID_8_VELOCITY) {
+            auto vel = message.as<Velocity>();
+            ASSERT_NEAR(vel.velocity, 0.0, 0.1);
+            ASSERT_NEAR(vel.vertical_velocity, 0.0, 0.1);
+          } else if (header.type == GSOF_ID_9_DOP) {
+            auto dop = message.as<PdopInfo>();
+            ASSERT_NEAR(dop.position_dop, 0.9f, 0.1);
+          } else if (header.type == GSOF_ID_10_CLOCK_INFO) {
+            auto clock = message.as<ClockInfo>();
+            ASSERT_TRUE(clock.isClockOffsetValid());
+            ASSERT_TRUE(clock.isFreqOffsetValid());
+          } else if (header.type == GSOF_ID_11_POS_VCV_INFO) {
+            auto vcv = message.as<PositionVcvInfo>();
+            ASSERT_EQ(vcv.num_epochs, 0);
+          } else if (header.type == GSOF_ID_12_POS_SIGMA) {
+            auto sigma = message.as<PositionSigmaInfo>();
+            ASSERT_EQ(sigma.number_epochs, 0);
+          } else if (header.type == GSOF_ID_15_REC_SERIAL_NUM) {
+            auto serial = message.as<ReceiverSerialNumber>();
+            ASSERT_EQ(serial.number, 573901788);
+          } else if (header.type == GSOF_ID_16_CURR_TIME) {
+            auto time = message.as<CurrentTime>();
+            ASSERT_EQ(time.gps_week, 2226);
+          }
+        }
+        ASSERT_EQ(parsed_message_count, expected_gsof_message_ids.size())
+            << "Parsed message count is different from the amount of messages in the GSOF stream.";
+      });
+
+  for (maybe_data = getData(); maybe_data.has_value(); maybe_data = getData()) {
+    parser.readSome(maybe_data->data, maybe_data->length);
+  }
+}
+
+class ApPlus20SmallStreamingGsofTest : public StreamingTest {
+ public:
+  ApPlus20SmallStreamingGsofTest()
+      : StreamingTest("applus20_small_tx.pcap", applus20_ip_addr, applus20_port, network::ProtocolType::TCP) {}
+};
+
+TEST_F(ApPlus20SmallStreamingGsofTest, singlePageStreamTest) {
+  // This test checks if the multipage stream parser works properly with a data stream that doesn't get split over
+  // multiple pages
+  trmb::gsof::StreamChapterParser parser;
+  std::optional<network::NonOwningBuffer> maybe_data = std::nullopt;
+
+  constexpr std::size_t k_expected_chapters = 10;
+  std::size_t chapter_count                 = 0;
+  uint32_t last_time                        = 0;
+
+  parser.registerGsofChapterFoundCallback([&chapter_count, &last_time](const std::vector<std::byte> &chapter) {
+    trmb::gsof::MessageParser message_parser(chapter.data(), chapter.size());
+
+    auto it = message_parser.begin();
+    ASSERT_EQ(it->getHeader().type, 49);
+
+    // Check time is monotonic
+    auto nav = it->as<trmb::gsof::NavigationSolution>();
+    ASSERT_GT(nav.gps_time.time_msec, last_time);
+    last_time = nav.gps_time.time_msec;
+
+    ++it;
+    ASSERT_EQ(it->getHeader().type, 50);
+    ++chapter_count;
+  });
+
+  for (maybe_data = getData(); maybe_data.has_value(); maybe_data = getData()) {
+    parser.readSome(maybe_data->data, maybe_data->length);
+  }
+
+  ASSERT_EQ(chapter_count, k_expected_chapters);
+}

--- a/trimble_driver/test/test_gsof_streaming_pcap.cpp
+++ b/trimble_driver/test/test_gsof_streaming_pcap.cpp
@@ -28,7 +28,9 @@ static constexpr int k_streaming_apx18_port       = 5018;
 class Apx18StreamingGsofTest : public StreamingTest {
  public:
   Apx18StreamingGsofTest()
-      : StreamingTest("apx_18_fullnav_fullrmsinfo.pcap", k_streaming_apx18_ip_addr, k_streaming_apx18_port,
+      : StreamingTest("apx_18_fullnav_fullrmsinfo.pcap",
+                      k_streaming_apx18_ip_addr,
+                      k_streaming_apx18_port,
                       network::ProtocolType::TCP) {}
 };
 

--- a/trimble_driver/test/test_ros_conversions.cpp
+++ b/trimble_driver/test/test_ros_conversions.cpp
@@ -16,32 +16,14 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-#include "streaming_test.h"
+#include "gsof_record_builder.h"
 #include "trimble_driver_ros/conversions.h"
 
+using gsof_test::makeGenoutRecord;
+using gsof_test::serialize;
 using trmb::gsof::Message;
 using trmb::gsof::PacketParser;
 using trmb::gsof::PublicPacketParser;
-
-static constexpr char k_ip_addr[] = "238.0.0.1";  // IP Address of SPS986
-static constexpr int k_port       = 5018;         // TCP Port used
-
-class RosConversionsTest : public ::testing::Test {
- public:
-  std::optional<PublicPacketParser> openPcap(const std::string &filename) {
-    pcap_reader_.emplace(filename, k_ip_addr, k_port, network::ProtocolType::TCP);
-    if (!(*pcap_reader_)) return std::nullopt;
-
-    pcap_reader_->readSingle(&payload_);
-    if (payload_.data == nullptr) return std::nullopt;
-
-    return PacketParser(reinterpret_cast<const std::byte *>(payload_.data), payload_.length);
-  }
-
- protected:
-  std::optional<network::PcapReader> pcap_reader_ = std::nullopt;
-  network::NonOwningBuffer payload_{nullptr, 0};
-};
 
 class RosRep103Test : public ::testing::Test {
  public:
@@ -166,11 +148,24 @@ TEST(RosConversions, gsof49INSAttitudeToQuaternion) {
   ASSERT_NEAR(odom.pose.pose.orientation.w, -0.7481401, tolerance);
 }
 
-// PCAP Test
-TEST_F(RosConversionsTest, gsof1toNavSatStatusPCAPTest) {
-  auto maybe_gsof_parser = openPcap("SPS986_gsof1.pcap");
-  ASSERT_TRUE(maybe_gsof_parser);
-  auto gsof_parser = *maybe_gsof_parser;
+TEST(RosConversions, gsof1toNavSatStatusEndToEnd) {
+  using namespace trmb::gsof;
+
+  const auto record = [] {
+    PositionTimeInfo expected{};
+    expected.header.type                = GSOF_ID_1_POS_TIME;
+    expected.header.length              = sizeof(PositionTimeInfo) - sizeof(Header);
+    expected.gps_time_ms                = 162117007;
+    expected.gps_week                   = 2225;
+    expected.number_space_vehicles_used = 25;
+    expected.position_flags_1           = 0b0000'1111;
+    expected.position_flags_2           = 0b0000'0111;  // Fixed integer phase differential solution
+
+    const auto message = serialize(expected);
+    return makeGenoutRecord(message.data(), message.size());
+  }();
+
+  PublicPacketParser gsof_parser(record.data(), record.size());
   ASSERT_TRUE(gsof_parser.isValid());
 
   auto message_parser = gsof_parser.getMessageParser();
@@ -179,7 +174,7 @@ TEST_F(RosConversionsTest, gsof1toNavSatStatusPCAPTest) {
   ASSERT_EQ(it->getHeader().type, 0x01);
   ASSERT_EQ(it->getHeader().length, 10);
 
-  auto position_time = it->as<trmb::gsof::PositionTimeInfo>();
+  auto position_time = it->as<PositionTimeInfo>();
 
   auto ros_nav_sat_status = trmb_ros::toNavSatStatus(position_time);
   ASSERT_EQ(ros_nav_sat_status.status, sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX);

--- a/trimble_driver/test/test_ros_conversions_pcap.cpp
+++ b/trimble_driver/test/test_ros_conversions_pcap.cpp
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2024. Trimble Inc.
+ * All rights reserved.
+ */
+
+/**
+ * ROS conversion regression test driven by a capture taken from a real receiver. It is built but deliberately not
+ * registered with ctest, see trmb_cc_test(NO_DISCOVER). Run the trimble_driver_pcap_test binary from test/data.
+ */
+
+#include <gtest/gtest.h>
+
+#ifdef TRMB_TF2_HEADER_DEPRECATED
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#else
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#endif
+
+#include "streaming_test.h"
+#include "trimble_driver/gsof/packet_parser.h"
+#include "trimble_driver_ros/conversions.h"
+
+using trmb::gsof::Message;
+using trmb::gsof::PacketParser;
+using trmb::gsof::PublicPacketParser;
+
+static constexpr char k_sps986_ip_addr[] = "238.0.0.1";  // IP Address of SPS986
+static constexpr int k_sps986_port       = 5018;         // TCP Port used
+
+class RosConversionsTest : public ::testing::Test {
+ public:
+  std::optional<PublicPacketParser> openPcap(const std::string &filename) {
+    pcap_reader_.emplace(filename, k_sps986_ip_addr, k_sps986_port, network::ProtocolType::TCP);
+    if (!(*pcap_reader_)) return std::nullopt;
+
+    pcap_reader_->readSingle(&payload_);
+    if (payload_.data == nullptr) return std::nullopt;
+
+    return PacketParser(reinterpret_cast<const std::byte *>(payload_.data), payload_.length);
+  }
+
+ protected:
+  std::optional<network::PcapReader> pcap_reader_ = std::nullopt;
+  network::NonOwningBuffer payload_{nullptr, 0};
+};
+
+TEST_F(RosConversionsTest, gsof1toNavSatStatusPCAPTest) {
+  auto maybe_gsof_parser = openPcap("SPS986_gsof1.pcap");
+  ASSERT_TRUE(maybe_gsof_parser);
+  auto gsof_parser = *maybe_gsof_parser;
+  ASSERT_TRUE(gsof_parser.isValid());
+
+  auto message_parser = gsof_parser.getMessageParser();
+  ASSERT_TRUE(message_parser.isValid());
+  auto it = message_parser.begin();
+  ASSERT_EQ(it->getHeader().type, 0x01);
+  ASSERT_EQ(it->getHeader().length, 10);
+
+  auto position_time = it->as<trmb::gsof::PositionTimeInfo>();
+
+  auto ros_nav_sat_status = trmb_ros::toNavSatStatus(position_time);
+  ASSERT_EQ(ros_nav_sat_status.status, sensor_msgs::msg::NavSatStatus::STATUS_GBAS_FIX);
+}


### PR DESCRIPTION
The ROS buildfarm doesn't support git lfs and thus all the unit tests fail. Made the main tests use synthetic data but also kept the old unit tests using recorded pcaps. These old tests can still be run and will run in github actions CI.