### PR TITLE
[jazzy] Backport fix for UB

### DIFF
--- a/trimble_driver/src/trimble_driver/gsof/stream_page_parser.cpp
+++ b/trimble_driver/src/trimble_driver/gsof/stream_page_parser.cpp
@@ -69,7 +69,10 @@ bool StreamPageParser::isGsofPageFound() {
   return packet_found;
 }
 
-bool StreamPageParser::isStartTxFound() { return static_cast<std::uint8_t>(buf_[0]) == START_TX; }
+bool StreamPageParser::isStartTxFound() {
+  if (buf_.empty()) return false;
+  return static_cast<std::uint8_t>(buf_[0]) == START_TX;
+}
 
 bool StreamPageParser::isHeaderFound() {
   // Need more data


### PR DESCRIPTION
Fix found in #41

Where there is a member that can be accessed before initialization